### PR TITLE
Add 'let' to core

### DIFF
--- a/src/Juvix/Core/HR/Types.hs
+++ b/src/Juvix/Core/HR/Types.hs
@@ -12,7 +12,9 @@ IR.extendTerm "Term" [] [t|T|] $
       { IR.nameLam = "Lam0",
         IR.typeLam = Just [[t|Symbol|]],
         IR.namePi = "Pi0",
-        IR.typePi = Just [[t|Symbol|]]
+        IR.typePi = Just [[t|Symbol|]],
+        IR.nameLet = "Let0",
+        IR.typeLet = Just [[t|Symbol|]]
       }
 
 -- TODO allow extendTerm to reorder fields?
@@ -20,7 +22,9 @@ pattern Lam x t = Lam0 t x
 
 pattern Pi π x s t = Pi0 π s t x
 
-{-# COMPLETE Star, PrimTy, Pi, Lam, Elim #-}
+pattern Let x l b = Let0 l b x
+
+{-# COMPLETE Star, PrimTy, Pi, Lam, Let, Elim #-}
 
 IR.extendElim "Elim" [] [t|T|] $
   \_primTy _primVal ->

--- a/src/Juvix/Core/HRAnn/Erasure.hs
+++ b/src/Juvix/Core/HRAnn/Erasure.hs
@@ -12,6 +12,7 @@ hrForgetter =
       etPrimTy = identity,
       etPi = identity,
       etLam = HRAnn.bindName,
+      etLet = HRAnn.bindName,
       etElim = const (),
       etBound = absurd,
       etFree = absurd,

--- a/src/Juvix/Core/HRAnn/Types.hs
+++ b/src/Juvix/Core/HRAnn/Types.hs
@@ -26,6 +26,8 @@ IR.extendTerm "Term" [] [t|T|] $
         IR.typeLam = Just [[t|BindAnnotation $primTy $primVal|]],
         IR.namePi = "Pi0",
         IR.typePi = Just [[t|Symbol|]],
+        IR.nameLet = "Let0",
+        IR.typeLet = Just [[t|BindAnnotation $primTy $primVal|]],
         IR.nameElim = "Elim0",
         IR.typeElim = Just [[t|Annotation $primTy $primVal|]]
       }
@@ -35,9 +37,11 @@ pattern Lam π x s t = Lam0 t (BindAnnotation x (Annotation π s))
 
 pattern Pi π x s t = Pi0 π s t x
 
+pattern Let π x s l b = Let0 l b (BindAnnotation x (Annotation π s))
+
 pattern Elim π s t = Elim0 s (Annotation π t)
 
-{-# COMPLETE Star, PrimTy, Pi, Lam, Elim #-}
+{-# COMPLETE Star, PrimTy, Pi, Lam, Let, Elim #-}
 
 data AppAnnotation primTy primVal = AppAnnotation
   { funAnn :: {-# UNPACK #-} !(Annotation primTy primVal),

--- a/src/Juvix/Core/IR/Evaluator.hs
+++ b/src/Juvix/Core/IR/Evaluator.hs
@@ -116,7 +116,7 @@ instance
   subst' i e (IR.Pi' π s t a) =
     IR.Pi' π (subst' i e s) (subst' (succ i) (weak' i e) t) (subst' i e a)
   subst' i e (IR.Lam' t a) =
-    IR.Lam' (subst' (succ i) (weak e) t) (subst' i e a)
+    IR.Lam' (subst' (succ i) (weak' i e) t) (subst' i e a)
   subst' i e (IR.Let' l b a) =
     IR.Let' (subst' i e l) (subst' (succ i) (weak' i e) b) (subst' i e a)
   subst' i e (IR.Elim' t a) =

--- a/src/Juvix/Core/IR/Evaluator.hs
+++ b/src/Juvix/Core/IR/Evaluator.hs
@@ -36,6 +36,8 @@ instance AllWeak ext primTy primVal => HasWeak (IR.Term' ext primTy primVal) whe
     IR.Pi' π (weak' i s) (weak' (succ i) t) (weak' i a)
   weak' i (IR.Lam' t a) =
     IR.Lam' (weak' (succ i) t) (weak' i a)
+  weak' i (IR.Let' l b a) =
+    IR.Let' (weak' i l) (weak' (succ i) b) (weak' i a)
   weak' i (IR.Elim' f a) =
     IR.Elim' (weak' i f) (weak' i a)
   weak' i (IR.TermX a) =
@@ -115,6 +117,8 @@ instance
     IR.Pi' π (subst' i e s) (subst' (succ i) (weak e) t) (subst' i e a)
   subst' i e (IR.Lam' t a) =
     IR.Lam' (subst' (succ i) (weak e) t) (subst' i e a)
+  subst' i e (IR.Let' l b a) =
+    IR.Let' (subst' i e l) (subst' (succ i) (weak' i e) b) (subst' i e a)
   subst' i e (IR.Elim' t a) =
     IR.Elim' (subst' i e t) (subst' i e a)
   subst' i e (IR.TermX a) =
@@ -387,6 +391,10 @@ evalTermWith exts param (IR.Pi' π s t _) =
   IR.VPi π <$> evalTermWith exts param s <*> evalTermWith exts param t
 evalTermWith exts param (IR.Lam' t _) =
   IR.VLam <$> evalTermWith exts param t
+evalTermWith exts param (IR.Let' l b _) = do
+  l' <- evalElimWith exts param l
+  b' <- evalTermWith exts param b
+  substValue param l' b'
 evalTermWith exts param (IR.Elim' e _) =
   evalElimWith exts param e
 evalTermWith (tExt, _) _ (IR.TermX a) =

--- a/src/Juvix/Core/IR/Evaluator.hs
+++ b/src/Juvix/Core/IR/Evaluator.hs
@@ -114,7 +114,7 @@ instance
   subst' i e (IR.PrimTy' t a) =
     IR.PrimTy' t (subst' i e a)
   subst' i e (IR.Pi' π s t a) =
-    IR.Pi' π (subst' i e s) (subst' (succ i) (weak e) t) (subst' i e a)
+    IR.Pi' π (subst' i e s) (subst' (succ i) (weak' i e) t) (subst' i e a)
   subst' i e (IR.Lam' t a) =
     IR.Lam' (subst' (succ i) (weak e) t) (subst' i e a)
   subst' i e (IR.Let' l b a) =

--- a/src/Juvix/Core/IR/TransformExt.hs
+++ b/src/Juvix/Core/IR/TransformExt.hs
@@ -8,20 +8,22 @@ import Juvix.Core.IR.Types (Elim, NoExt, Term)
 import Juvix.Core.IR.Types.Base
 import Juvix.Library hiding (Coerce)
 
-data ExtTransformTEF f ext1 ext2 primTy primVal = ExtTransformTEF
-  { etfStar :: XStar ext1 primTy primVal -> f (XStar ext2 primTy primVal),
-    etfPrimTy :: XPrimTy ext1 primTy primVal -> f (XPrimTy ext2 primTy primVal),
-    etfPi :: XPi ext1 primTy primVal -> f (XPi ext2 primTy primVal),
-    etfLam :: XLam ext1 primTy primVal -> f (XLam ext2 primTy primVal),
-    etfElim :: XElim ext1 primTy primVal -> f (XElim ext2 primTy primVal),
-    etfBound :: XBound ext1 primTy primVal -> f (XBound ext2 primTy primVal),
-    etfFree :: XFree ext1 primTy primVal -> f (XFree ext2 primTy primVal),
-    etfPrim :: XPrim ext1 primTy primVal -> f (XPrim ext2 primTy primVal),
-    etfApp :: XApp ext1 primTy primVal -> f (XApp ext2 primTy primVal),
-    etfAnn :: XAnn ext1 primTy primVal -> f (XAnn ext2 primTy primVal),
-    etfTermX :: TermX ext1 primTy primVal -> f (TermX ext2 primTy primVal),
-    etfElimX :: ElimX ext1 primTy primVal -> f (ElimX ext2 primTy primVal)
-  }
+data ExtTransformTEF f ext1 ext2 primTy primVal
+  = ExtTransformTEF
+      { etfStar :: XStar ext1 primTy primVal -> f (XStar ext2 primTy primVal),
+        etfPrimTy :: XPrimTy ext1 primTy primVal -> f (XPrimTy ext2 primTy primVal),
+        etfPi :: XPi ext1 primTy primVal -> f (XPi ext2 primTy primVal),
+        etfLam :: XLam ext1 primTy primVal -> f (XLam ext2 primTy primVal),
+        etfLet :: XLet ext1 primTy primVal -> f (XLet ext2 primTy primVal),
+        etfElim :: XElim ext1 primTy primVal -> f (XElim ext2 primTy primVal),
+        etfBound :: XBound ext1 primTy primVal -> f (XBound ext2 primTy primVal),
+        etfFree :: XFree ext1 primTy primVal -> f (XFree ext2 primTy primVal),
+        etfPrim :: XPrim ext1 primTy primVal -> f (XPrim ext2 primTy primVal),
+        etfApp :: XApp ext1 primTy primVal -> f (XApp ext2 primTy primVal),
+        etfAnn :: XAnn ext1 primTy primVal -> f (XAnn ext2 primTy primVal),
+        etfTermX :: TermX ext1 primTy primVal -> f (TermX ext2 primTy primVal),
+        etfElimX :: ElimX ext1 primTy primVal -> f (ElimX ext2 primTy primVal)
+      }
 
 type ExtTransformTE = ExtTransformTEF Identity
 
@@ -36,6 +38,7 @@ pattern ExtTransformTE ::
   (XPrimTy ext1 primTy primVal -> XPrimTy ext2 primTy primVal) ->
   (XPi ext1 primTy primVal -> XPi ext2 primTy primVal) ->
   (XLam ext1 primTy primVal -> XLam ext2 primTy primVal) ->
+  (XLet ext1 primTy primVal -> XLet ext2 primTy primVal) ->
   (XElim ext1 primTy primVal -> XElim ext2 primTy primVal) ->
   (XBound ext1 primTy primVal -> XBound ext2 primTy primVal) ->
   (XFree ext1 primTy primVal -> XFree ext2 primTy primVal) ->
@@ -50,6 +53,7 @@ pattern ExtTransformTE
     etPrimTy,
     etPi,
     etLam,
+    etLet,
     etElim,
     etBound,
     etFree,
@@ -64,6 +68,7 @@ pattern ExtTransformTE
       etfPrimTy = Coerce etPrimTy,
       etfPi = Coerce etPi,
       etfLam = Coerce etLam,
+      etfLet = Coerce etLet,
       etfElim = Coerce etElim,
       etfBound = Coerce etBound,
       etfFree = Coerce etFree,
@@ -82,10 +87,10 @@ extTransformTF ::
 extTransformTF fs (Star' i e) = Star' i <$> etfStar fs e
 extTransformTF fs (PrimTy' k e) = PrimTy' k <$> etfPrimTy fs e
 extTransformTF fs (Pi' π s t e) =
-  Pi' π <$> extTransformTF fs s
-    <*> extTransformTF fs t
-    <*> etfPi fs e
+  Pi' π <$> extTransformTF fs s <*> extTransformTF fs t <*> etfPi fs e
 extTransformTF fs (Lam' t e) = Lam' <$> extTransformTF fs t <*> etfLam fs e
+extTransformTF fs (Let' l b e) =
+  Let' <$> extTransformEF fs l <*> extTransformTF fs b <*> etfLet fs e
 extTransformTF fs (Elim' f e) = Elim' <$> extTransformEF fs f <*> etfElim fs e
 extTransformTF fs (TermX e) = TermX <$> etfTermX fs e
 
@@ -131,6 +136,7 @@ forgetter =
       etPrimTy = const (),
       etPi = const (),
       etLam = const (),
+      etLet = const (),
       etElim = const (),
       etBound = const (),
       etFree = const (),

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -149,6 +149,13 @@ typeTerm p ii ctx tm@(IR.Lam m) ann@(Annotation σ ty) = do
       tellLog $ Typechecked tm ann
       pure $ Typed.Lam mAnn ann
     _ -> throwLog $ ShouldBeFunctionType ty tm
+-- let case
+typeTerm p ii ctx (IR.Let l b) ann = do
+  tellLog CheckingLet
+  l' <- typeElim p ii ctx l
+  let ctx' = ContextElement (IR.Local ii) (getElimAnn l') : ctx
+  b' <- typeTerm p (succ ii) ctx' b ann
+  pure $ Typed.Let l' b' (getTermAnn b')
 -- elim case
 typeTerm p ii ctx tm@(IR.Elim e) ann@(Annotation σ ty) = do
   tellLogs [TermIntro ctx tm ann, CheckingElim]

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -154,8 +154,9 @@ typeTerm p ii ctx (IR.Let l b) ann = do
   tellLog CheckingLet
   l' <- typeElim p ii ctx l
   let ctx' = ContextElement (IR.Local ii) (getElimAnn l') : ctx
-  b' <- typeTerm p (succ ii) ctx' b ann
-  pure $ Typed.Let l' b' (getTermAnn b')
+      b'   = Eval.substTerm (IR.Free (IR.Local ii)) b
+  bAnn <- typeTerm p (succ ii) ctx' b' ann
+  pure $ Typed.Let l' bAnn ann
 -- elim case
 typeTerm p ii ctx tm@(IR.Elim e) ann@(Annotation σ ty) = do
   tellLogs [TermIntro ctx tm ann, CheckingElim]

--- a/src/Juvix/Core/IR/Typechecker/Log.hs
+++ b/src/Juvix/Core/IR/Typechecker/Log.hs
@@ -37,6 +37,7 @@ data Log primTy primVal
   | CheckingLam
   | LamAnnIsPi
   | LamBodyWith Usage.T Usage.T
+  | CheckingLet
   | CheckingElim
   | InferringFree
   | FoundFree (Typed.Annotation primTy primVal)
@@ -139,19 +140,14 @@ describe CheckingLam =
     ]
 describe LamAnnIsPi =
   "- Input annotation is a function type.\n"
-describe (LamBodyWith σ π) =
-  mconcat
-    [ "- Checking the body with the argument at usage σ·π, i.e.\n\t",
-      show σ,
-      " *\n\t",
-      show π,
-      ".\n"
-    ]
-describe CheckingElim =
-  mconcat
-    [ "- Matched an elimination term.\n",
-      "  Checking the input type is compatible with the inferred type.\n"
-    ]
+describe (LamBodyWith σ π) = mconcat
+  ["- Checking the body with the argument at usage σ·π, i.e.\n\t",
+   show σ, " *\n\t", show π, ".\n"]
+describe CheckingLet =
+  "- Matched a let expression."
+describe CheckingElim = mconcat
+  ["- Matched an elimination term.\n",
+   "  Checking the input type is compatible with the inferred type.\n"]
 describe InferringFree =
   "- Matched a free variable. Checking it is in the context.\n"
 describe (FoundFree (Annotation π ty)) =
@@ -238,6 +234,7 @@ logType (CheckingPiArg {}) = Info
 logType (CheckingPiRes {}) = Info
 logType (CheckingPrimTy {}) = Info
 logType (CheckingLam {}) = Info
+logType (CheckingLet {}) = Info
 logType (LamAnnIsPi {}) = Pass
 logType (LamBodyWith {}) = Info
 logType (CheckingElim {}) = Info

--- a/src/Juvix/Core/IR/Typechecker/Types.hs
+++ b/src/Juvix/Core/IR/Typechecker/Types.hs
@@ -169,6 +169,7 @@ IR.extendTerm "Term" [] [t|T|] $
             IR.typePrimTy = typed,
             IR.typePi = typed,
             IR.typeLam = typed,
+            IR.typeLet = typed,
             IR.typeElim = typed
           }
 
@@ -188,6 +189,7 @@ getTermAnn (Star _ ann) = ann
 getTermAnn (PrimTy _ ann) = ann
 getTermAnn (Pi _ _ _ ann) = ann
 getTermAnn (Lam _ ann) = ann
+getTermAnn (Let _ _ ann) = ann
 getTermAnn (Elim _ ann) = ann
 
 getElimAnn :: Elim primTy primVal -> Annotation primTy primVal

--- a/src/Juvix/Core/IR/Types/Base.hs
+++ b/src/Juvix/Core/IR/Types/Base.hs
@@ -32,6 +32,9 @@ extensible
       | -- | LAM Introduction rule of PI.
         -- The abstracted variables usage is tracked with the Usage(π).
         Lam (Term primTy primVal)
+      | -- | Let binder.
+        -- the local definition is bound to de Bruijn index 0.
+        Let (Elim primTy primVal) (Term primTy primVal)
       | -- | CONV conversion rule. TODO make sure 0Γ ⊢ S≡T
         -- Elim is the constructor that embeds Elim to Term
         Elim (Elim primTy primVal)

--- a/src/Juvix/Core/Translate.hs
+++ b/src/Juvix/Core/Translate.hs
@@ -25,6 +25,10 @@ hrToIR' term =
     HR.Lam n b -> do
       b <- withName n $ hrToIR' b
       pure (IR.Lam b)
+    HR.Let n l b -> do
+      l <- hrElimToIR' l
+      b <- withName n $ hrToIR' b
+      pure (IR.Let l b)
     HR.Elim e -> IR.Elim |<< hrElimToIR' e
 
 hrElimToIR' ::
@@ -70,6 +74,11 @@ irToHR' term =
       n <- newName
       t <- irToHR' t
       pure (HR.Lam n t)
+    IR.Let l b -> do
+      l <- irElimToHR' l
+      n <- newName
+      b <- irToHR' b
+      pure (HR.Let n l b)
     IR.Elim e -> HR.Elim |<< irElimToHR' e
 
 irElimToHR' ::


### PR DESCRIPTION
More specifically, a `let` binds an *elimination* to a single variable (not an arbitrary pattern), and the body is a term.