### PR TITLE
Add 'let' to forgotten places

### DIFF
--- a/src/Juvix/Core/EAC/ConstraintGen.hs
+++ b/src/Juvix/Core/EAC/ConstraintGen.hs
@@ -205,7 +205,7 @@ boxAndTypeConstraint parameterisation parameterizedAssignment term = do
       -- Return parameterized term.
       pure (EAC.RBang param (EAC.RLam sym body), resTy)
     Erased.Let s t b -> do
-      _ -- ?????????????????
+      error "TODO"
     Erased.App a b -> do
       (a, aTy) <- rec a
       let EAC.PArrT bangA argTy resTy = aTy

--- a/src/Juvix/Core/EAC/ConstraintGen.hs
+++ b/src/Juvix/Core/EAC/ConstraintGen.hs
@@ -23,6 +23,9 @@ setOccurrenceMap term = do
       modify' @"occurrenceMap" (Map.insertWith (+) sym 1)
     Erased.Lam _ b -> do
       setOccurrenceMap b
+    Erased.Let _ b t -> do
+      setOccurrenceMap b
+      setOccurrenceMap t
     Erased.App a b -> do
       setOccurrenceMap a
       setOccurrenceMap b
@@ -201,6 +204,8 @@ boxAndTypeConstraint parameterisation parameterizedAssignment term = do
         (EAC.Constraint [EAC.ConstraintVar 1 (bangParam resTy)] (EAC.Gte 0))
       -- Return parameterized term.
       pure (EAC.RBang param (EAC.RLam sym body), resTy)
+    Erased.Let s t b -> do
+      _ -- ?????????????????
     Erased.App a b -> do
       (a, aTy) <- rec a
       let EAC.PArrT bangA argTy resTy = aTy

--- a/src/Juvix/Core/Erased/Types.hs
+++ b/src/Juvix/Core/Erased/Types.hs
@@ -9,6 +9,7 @@ data Term primVal
   | Prim primVal
   | -- TODO ∷ add proper lam with capture and arguments here!
     Lam Symbol (Term primVal)
+  | Let Symbol (Term primVal) (Term primVal)
   | App (Term primVal) (Term primVal)
   deriving (Show, Eq, Generic)
 

--- a/src/Juvix/Core/Erased/Util.hs
+++ b/src/Juvix/Core/Erased/Util.hs
@@ -11,5 +11,6 @@ free term =
           Var s -> if Set.member s used then Set.empty else Set.singleton s
           Prim _ -> Set.empty
           Lam v b -> go (Set.insert v used) b
+          Let v b t -> go used b `Set.union` go (Set.insert v used) t
           App a b -> go used a `Set.union` go used b
    in Set.toList (go Set.empty term)

--- a/src/Juvix/Interpreter/InteractionNet.hs
+++ b/src/Juvix/Interpreter/InteractionNet.hs
@@ -20,6 +20,7 @@ erasedCoreToInteractionNetAST term =
     Erased.Var s -> Symbol' s
     Erased.Prim p -> Prim p
     Erased.Lam s t -> Lambda s (erasedCoreToInteractionNetAST t)
+    Erased.Let s b t -> Let s (erasedCoreToInteractionNetAST b) (erasedCoreToInteractionNetAST t)
     Erased.App f x ->
       Application (erasedCoreToInteractionNetAST f) (erasedCoreToInteractionNetAST x)
 


### PR DESCRIPTION
So um, like I said, I often lose the 'incomplete patterns' warnings amongst the rest of Stack's output. Sorry.

Anyway, part of this PR is adding `let` to erased core. Unfortunately I have no idea what to do for `Juvix.Core.EAC.ConstraintGen.boxAndTypeConstraint` so I'll need some help with that.