### PR TITLE
Cleaned up Some parts of Arithmetic Circuit

### DIFF
--- a/doc/Code/Juvix.org
+++ b/doc/Code/Juvix.org
@@ -15,6 +15,7 @@
 **** ZKP
 - _Relies on_
   + [[ArithmeticCircuit/Compilation]]
+  + [[Library]]
 **** Compilation <<ArithmeticCircuit/Compilation>>
 - _Relies on_
   + [[Compilation/Environment]]
@@ -23,12 +24,14 @@
   + [[ErasedAnn]]
   + [[Usage]]
   + [[Library]]
-  + [[Library]]
 ***** Environment <<Compilation/Environment>>
 - _Relies on_
   + [[ArithmeticCircuit/Compilation/Types]]
   + [[Library]]
 ***** Types <<ArithmeticCircuit/Compilation/Types>>
+Provides the various types needed for the arithmetic circuit
+backend
+- Expression covers the gambit of arithmetic circuit expressions
 - _Relies on_
   + [[ArithmeticCircuit/Parameterisation]]
   + [[ErasedAnn]]

--- a/src/Juvix/Backends/ArithmeticCircuit/Compilation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Compilation.hs
@@ -10,8 +10,8 @@ module Juvix.Backends.ArithmeticCircuit.Compilation
     c,
     and',
     or',
-    Term,
-    Type,
+    Types.Term,
+    Types.Type,
     lambda,
     var,
     input,
@@ -26,38 +26,43 @@ import qualified Circuit
 import qualified Circuit.Expr as Expr
 import qualified Circuit.Lang as Lang
 import qualified Data.Map ()
-import Juvix.Backends.ArithmeticCircuit.Compilation.Environment
-import Juvix.Backends.ArithmeticCircuit.Compilation.Types
+import qualified Juvix.Backends.ArithmeticCircuit.Compilation.Environment as Env
+import qualified Juvix.Backends.ArithmeticCircuit.Compilation.Types as Types
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation as Par
 import qualified Juvix.Core.ErasedAnn as CoreErased
 import qualified Juvix.Core.Usage as Usage
 import Juvix.Library hiding (Type, exp)
-import qualified Juvix.Library as J
 import Numeric.Natural ()
 
-compile :: Term -> Type -> (Either CompilationError ArithExpression, Circuit.ArithCircuit Par.F)
-compile term _ = toArithCircuit <$> runState (runExceptT (antiAlias $ transTerm term)) (Env mempty NoExp)
+compile ::
+  Types.Term ->
+  Types.Type ->
+  (Either Types.CompilationError Types.Expression, Circuit.ArithCircuit Par.F)
+compile term _ =
+  Env.Env mempty Types.NoExp
+    |> runState (runExceptT (Env.antiAlias $ transTerm term))
+    |> fmap toArithCircuit
   where
     toArithCircuit env =
-      case compilation env of
-        BoolExp exp -> runCirc exp
-        FExp exp -> runCirc exp
-        NoExp -> panic "Tried to compile an empty circuit"
+      case Env.compilation env of
+        Types.BoolExp exp -> runCirc exp
+        Types.FExp exp -> runCirc exp
+        Types.NoExp -> panic "Tried to compile an empty circuit"
 
 runCirc :: Num f => Expr.Expr Circuit.Wire f ty -> Circuit.ArithCircuit f
 runCirc = Expr.execCircuitBuilder . Expr.compile
 
-transTerm :: Term -> ArithmeticCircuitCompilation ArithExpression
+transTerm :: Env.HasCompErr m => Types.Term -> m Types.Expression
 transTerm CoreErased.Ann {CoreErased.term = CoreErased.Prim term} =
   transPrim term
-transTerm CoreErased.Ann {CoreErased.term = CoreErased.Var var} =
-  do
-    (n, exp) <- lookup var
-    case exp of
-      NoExp -> do
-        _ <- insert var (FExp $ input n)
-        write (FExp $ input n)
-      _ -> write exp
+transTerm CoreErased.Ann {CoreErased.term = CoreErased.Var var} = do
+  (n, exp) <- Env.lookup var
+  case exp of
+    Types.NoExp -> do
+      _ <- Env.insert var (Types.FExp $ input n)
+      Env.write (Types.FExp $ input n)
+    _ ->
+      Env.write exp
 transTerm
   CoreErased.Ann
     { CoreErased.term =
@@ -65,10 +70,9 @@ transTerm
           { CoreErased.body = body,
             CoreErased.arguments = arguments
           }
-    } =
-    do
-      freshVars arguments
-      transTerm body
+    } = do
+    Env.freshVars arguments
+    transTerm body
 transTerm CoreErased.Ann {CoreErased.term = CoreErased.AppM f params} =
   case f of
     ( CoreErased.Ann
@@ -78,108 +82,144 @@ transTerm CoreErased.Ann {CoreErased.term = CoreErased.AppM f params} =
                 CoreErased.arguments = arguments
               }
         }
-      ) ->
-        do
-          mapM_ execParams (zip arguments params)
-          term <- transTerm body
-          -- We must remove variables introduced by current function
-          mapM_ remove arguments
-          return term
+      ) -> do
+        traverse_ execParams (zip arguments params)
+        term <- transTerm body
+        -- We must remove variables introduced by current function
+        traverse_ Env.remove arguments
+        return term
         where
-          execParams :: (Symbol, Term) -> ArithmeticCircuitCompilation ArithExpression
-          execParams (sy, term) =
-            do
-              term' <- transTerm term
-              insert sy term'
-    _ -> throw @"compilationError" TypeErrorApplicationNonFunction
+          execParams (sy, term) = do
+            term' <- transTerm term
+            Env.insert sy term'
+    _ -> throw @"compilationError" Types.TypeErrorApplicationNonFunction
 
-transPrim :: PrimVal -> ArithmeticCircuitCompilation ArithExpression
-transPrim (Element f) = write . FExp $ Lang.c f
-transPrim (Boolean b) = write . BoolExp $ Circuit.EConstBool b
-transPrim (FEInteger i) = write . FExp $ Lang.c (fromIntegral i)
--- ArithExpression cannot be made a Functor since the structure inside it is not a Functor
--- It is a Bifunctor where I need to fix the last variant, making it a Contravariant Functor
--- Therefore, we are sticking to manual Applicative until we move away from `arithmetic-circuits`
-transPrim (BinOp Add prim prim') = do
-  prim1 <- transTerm prim
-  prim2 <- transTerm prim'
-  case (prim1, prim2) of
-    (FExp prim1', FExp prim2') -> (write . FExp) $ Lang.add prim1' prim2'
-    (_, _) -> throw @"compilationError" PrimTypeError
-transPrim (BinOp Mul prim prim') = do
-  prim1 <- transTerm prim
-  prim2 <- transTerm prim'
-  case (prim1, prim2) of
-    (FExp prim1', FExp prim2') -> (write . FExp) $ Lang.mul prim1' prim2'
-    (_, _) -> throw @"compilationError" PrimTypeError
-transPrim (BinOp Sub prim prim') = do
-  prim1 <- transTerm prim
-  prim2 <- transTerm prim'
-  case (prim1, prim2) of
-    (FExp prim1', FExp prim2') -> (write . FExp) $ Lang.sub prim1' prim2'
-    (_, _) -> throw @"compilationError" PrimTypeError
--- It implements exponentiation by hand since `arithmetic-circuits` does not support it
-transPrim (BinOp Exp prim CoreErased.Ann {CoreErased.term = CoreErased.Prim (FEInteger i)})
-  | i == 1 = transTerm prim
-  | otherwise = transPrim (BinOp Mul prim (wrap $ BinOp Exp prim (wrap $ FEInteger (i - 1))))
-transPrim (BinOp Eq prim prim') = do
-  prim1 <- transTerm prim
-  prim2 <- transTerm prim'
-  case (prim1, prim2) of
-    (FExp prim1', FExp prim2') -> (write . BoolExp) $ Lang.eq prim1' prim2'
-    (_, _) -> throw @"compilationError" PrimTypeError
-transPrim (BinOp And prim prim') = do
-  prim1 <- transTerm prim
-  prim2 <- transTerm prim'
-  case (prim1, prim2) of
-    (BoolExp prim1', BoolExp prim2') -> (write . BoolExp) $ Lang.and_ prim1' prim2'
-    (_, _) -> throw @"compilationError" PrimTypeError
-transPrim (BinOp Or prim prim') = do
-  prim1 <- transTerm prim
-  prim2 <- transTerm prim'
-  case (prim1, prim2) of
-    (BoolExp prim1', BoolExp prim2') -> (write . BoolExp) $ Lang.or_ prim1' prim2'
-    (_, _) -> throw @"compilationError" PrimTypeError
-transPrim (UnaryOp Neg prim) = do
+-- - _for the calls below FEInteger_
+--   + Types.Expression cannot be made a Functor since the structure
+--     inside it is not a Functor It is a Bifunctor where I need to fix
+--     the last variant, making it a Contravariant Functor Therefore, we
+--     are sticking to manual Applicative until we move away from
+--     `arithmetic-circuits`
+-- - _for the Types.BinOp Types.Exp_
+--   + we implement exponentiation by hand
+--     since `arithmetic-circuits` does not support it
+
+transPrim :: Env.HasCompErr m => Types.PrimVal -> m Types.Expression
+transPrim (Types.Element f) = Env.write . Types.FExp $ Lang.c f
+transPrim (Types.Boolean b) = Env.write . Types.BoolExp $ Circuit.EConstBool b
+transPrim (Types.FEInteger i) = Env.write . Types.FExp $ Lang.c (fromIntegral i)
+--
+transPrim (Types.BinOp Types.Add prim prim') = onTwoPrimF Lang.add prim prim'
+transPrim (Types.BinOp Types.Mul prim prim') = onTwoPrimF Lang.mul prim prim'
+transPrim (Types.BinOp Types.Sub prim prim') = onTwoPrimF Lang.sub prim prim'
+transPrim (Types.BinOp Types.And prim prim') = onTwoPrimBool Lang.and_ prim prim'
+transPrim (Types.BinOp Types.Eq prim prim') = onTwoPrimFEq Lang.eq prim prim'
+transPrim (Types.BinOp Types.Or prim prim') = onTwoPrimBool Lang.or_ prim prim'
+transPrim (Types.UnaryOp Types.Neg prim) = do
   prim1 <- transTerm prim
   case prim1 of
-    BoolExp prim1' -> (write . BoolExp) $ Lang.not_ prim1'
-    _ -> throw @"compilationError" PrimTypeError
-transPrim (If prim prim' prim'') = do
+    Types.BoolExp prim1' ->
+      Lang.not_ prim1'
+        |> Types.BoolExp
+        |> Env.write
+    _ -> throw @"compilationError" Types.PrimTypeError
+transPrim (Types.If prim prim' prim'') = do
   prim1 <- transTerm prim
   prim2 <- transTerm prim'
   prim3 <- transTerm prim''
   case (prim1, prim2, prim3) of
-    (BoolExp prim1', FExp prim2', FExp prim3') -> (write . FExp) $ Lang.cond prim1' prim2' prim3'
-    (_, _, _) -> throw @"compilationError" PrimTypeError
-transPrim _ = throw @"compilationError" PrimTypeError
+    (Types.BoolExp prim1', Types.FExp prim2', Types.FExp prim3') ->
+      (Env.write . Types.FExp) $ Lang.cond prim1' prim2' prim3'
+    (_, _, _) -> throw @"compilationError" Types.PrimTypeError
+transPrim
+  ( Types.BinOp
+      Types.Exp
+      prim
+      CoreErased.Ann
+        { CoreErased.term = CoreErased.Prim (Types.FEInteger i)
+        }
+    )
+    | i == 1 =
+      transTerm prim
+    | otherwise =
+      Types.FEInteger (i - 1)
+        |> wrap
+        |> Types.BinOp Types.Exp prim
+        |> wrap
+        |> Types.BinOp Types.Mul prim
+        |> transPrim
+transPrim (Types.BinOp Types.Exp _ _) =
+  throw @"compilationError" Types.PrimTypeError
 
-add, mul, sub, eq, and', or', exp :: Term -> Term -> Term
-add term term' = wrap (BinOp Add term term')
-mul term term' = wrap (BinOp Mul term term')
-sub term term' = wrap (BinOp Sub term term')
-eq term term' = wrap (BinOp Eq term term')
-and' term term' = wrap (BinOp And term term')
-or' term term' = wrap (BinOp Or term term')
-exp term term' = wrap (BinOp Exp term term')
+type CircuitExp t =
+  Expr.Expr Circuit.Wire Par.F t
 
-neg :: Term -> Term
-neg = wrap . UnaryOp Neg
+type TwoPrimExpression input res m =
+  Env.HasCompErr m =>
+  (input -> input -> res) ->
+  Types.Term ->
+  Types.Term ->
+  m Types.Expression
 
-c :: Par.F -> Term
-c = wrap . Element
+onTwoPrim :: TwoPrimExpression Types.Expression (m Types.Expression) m
+onTwoPrim f prim1 prim2 = do
+  prim1 <- transTerm prim1
+  prim2 <- transTerm prim2
+  f prim1 prim2
 
-int :: Int -> Term
-int = wrap . FEInteger
+onTwoPrimBool :: TwoPrimExpression (CircuitExp Bool) (CircuitExp Bool) m
+onTwoPrimBool f =
+  onTwoPrim g
+  where
+    g (Types.BoolExp prim1) (Types.BoolExp prim2) =
+      f prim1 prim2
+        |> Types.BoolExp
+        |> Env.write
+    g _ _ = throw @"compilationError" Types.PrimTypeError
 
-true, false :: Term
-true = wrap $ Boolean True
-false = wrap $ Boolean False
+onTwoPrimFGen ::
+  (a -> Types.Expression) -> TwoPrimExpression (CircuitExp Par.F) a m
+onTwoPrimFGen ret f =
+  onTwoPrim g
+  where
+    g (Types.FExp prim1) (Types.FExp prim2) =
+      f prim1 prim2
+        |> ret
+        |> Env.write
+    g _ _ = throw @"compilationError" Types.PrimTypeError
 
-cond :: Term -> Term -> Term -> Term
-cond term term' term'' = wrap (If term term' term'')
+onTwoPrimF :: TwoPrimExpression (CircuitExp Par.F) (CircuitExp Par.F) m
+onTwoPrimF = onTwoPrimFGen Types.FExp
 
-wrap :: PrimVal -> Term
+onTwoPrimFEq :: TwoPrimExpression (CircuitExp Par.F) (CircuitExp Bool) m
+onTwoPrimFEq = onTwoPrimFGen Types.BoolExp
+
+add, mul, sub, eq, and', or', exp :: Types.Term -> Types.Term -> Types.Term
+add term term' = wrap (Types.BinOp Types.Add term term')
+mul term term' = wrap (Types.BinOp Types.Mul term term')
+sub term term' = wrap (Types.BinOp Types.Sub term term')
+eq term term' = wrap (Types.BinOp Types.Eq term term')
+and' term term' = wrap (Types.BinOp Types.And term term')
+or' term term' = wrap (Types.BinOp Types.Or term term')
+exp term term' = wrap (Types.BinOp Types.Exp term term')
+
+neg :: Types.Term -> Types.Term
+neg = wrap . Types.UnaryOp Types.Neg
+
+c :: Par.F -> Types.Term
+c = wrap . Types.Element
+
+int :: Int -> Types.Term
+int = wrap . Types.FEInteger
+
+true, false :: Types.Term
+true = wrap $ Types.Boolean True
+false = wrap $ Types.Boolean False
+
+cond :: Types.Term -> Types.Term -> Types.Term -> Types.Term
+cond term term' term'' = wrap (Types.If term term' term'')
+
+wrap :: Types.PrimVal -> Types.Term
 wrap prim =
   CoreErased.Ann
     { CoreErased.term = CoreErased.Prim prim,
@@ -187,7 +227,7 @@ wrap prim =
       CoreErased.type' = CoreErased.PrimTy ()
     }
 
-var :: J.Symbol -> Term
+var :: Symbol -> Types.Term
 var x =
   CoreErased.Ann
     { CoreErased.term = CoreErased.Var x,
@@ -195,7 +235,7 @@ var x =
       CoreErased.type' = CoreErased.PrimTy ()
     }
 
-lambda :: [J.Symbol] -> Term -> Term
+lambda :: [Symbol] -> Types.Term -> Types.Term
 lambda args body =
   CoreErased.Ann
     { CoreErased.term =

--- a/src/Juvix/Backends/ArithmeticCircuit/Compilation/Environment.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Compilation/Environment.hs
@@ -1,18 +1,16 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TupleSections #-}
 
 module Juvix.Backends.ArithmeticCircuit.Compilation.Environment where
 
-import qualified Control.Monad.Fail as Fail
 import qualified Data.Map as Map
-import Juvix.Backends.ArithmeticCircuit.Compilation.Types
+import qualified Juvix.Backends.ArithmeticCircuit.Compilation.Types as Types
 import Juvix.Library
 
-data Memory = Mem (Map.Map Symbol (Int, ArithExpression)) Int
+data Memory = Mem (Map.Map Symbol (Int, Types.Expression)) Int
   deriving (Generic)
 
 instance Semigroup Memory where
-  (Mem map_ n) <> (Mem map__ m) = Mem (map_ <> Map.map (shift n) map__) (n + m)
+  (Mem map' n) <> (Mem map'' m) = Mem (map' <> fmap (shift n) map'') (n + m)
     where
       shift n (m, exp) = (n + m, exp)
 
@@ -23,72 +21,74 @@ instance Monoid Memory where
 data Env
   = Env
       { memory :: Memory,
-        compilation :: ArithExpression
+        compilation :: Types.Expression
       }
   deriving (Generic)
 
-type ArithmeticCircuitCompilationAlias = ExceptT CompilationError (State Env)
+type CompilationAlias = ExceptT Types.CompilationError (State Env)
 
-newtype ArithmeticCircuitCompilation a = Compilation {antiAlias :: (ArithmeticCircuitCompilationAlias a)}
+newtype Compilation a
+  = Compilation {antiAlias :: (CompilationAlias a)}
   deriving (Functor, Applicative, Monad)
   deriving
     ( HasState "memory" Memory,
       HasSink "memory" Memory,
       HasSource "memory" Memory
     )
-    via StateField "memory" ArithmeticCircuitCompilationAlias
+    via StateField "memory" CompilationAlias
   deriving
-    ( HasState "compilation" ArithExpression,
-      HasSink "compilation" ArithExpression,
-      HasSource "compilation" ArithExpression
+    ( HasState "compilation" Types.Expression,
+      HasSink "compilation" Types.Expression,
+      HasSource "compilation" Types.Expression
     )
-    via StateField "compilation" ArithmeticCircuitCompilationAlias
+    via StateField "compilation" CompilationAlias
   deriving
-    (HasThrow "compilationError" CompilationError)
-    via MonadError ArithmeticCircuitCompilationAlias
+    (HasThrow "compilationError" Types.CompilationError)
+    via MonadError CompilationAlias
 
-insert :: Symbol -> ArithExpression -> ArithmeticCircuitCompilation ArithExpression
+type HasMemory m = HasState "memory" Memory m
+
+type HasComp m = (HasMemory m, HasState "compilation" Types.Expression m)
+
+type HasMemoryErr m = (HasMemory m, HasThrow "compilationError" Types.CompilationError m)
+
+type HasCompErr m = (HasComp m, HasThrow "compilationError" Types.CompilationError m)
+
+insert :: HasMemory m => Symbol -> Types.Expression -> m Types.Expression
 insert sy exp =
-  do
-    modify @"memory" (insert' sy exp)
-    return exp
+  modify @"memory" (insert' sy exp) *> return exp
   where
-    insert' :: Symbol -> ArithExpression -> Memory -> Memory
+    insert' :: Symbol -> Types.Expression -> Memory -> Memory
     insert' sy x (Mem map_ n) = Mem (Map.insert sy (n, x) map_) (n + 1)
 
-remove :: Symbol -> ArithmeticCircuitCompilation ()
+remove :: HasMemory m => Symbol -> m ()
 remove sy =
-  do
-    modify @"memory" (remove' sy)
+  modify @"memory" (remove' sy)
   where
     remove' :: Symbol -> Memory -> Memory
     remove' sy (Mem map_ n) = Mem (Map.delete sy map_) (n - 1)
 
-lookup :: Symbol -> ArithmeticCircuitCompilation (Int, ArithExpression)
-lookup sy =
-  do
-    mem <- get @"memory"
-    lookup' sy mem
-  where
-    lookup' :: Symbol -> Memory -> ArithmeticCircuitCompilation (Int, ArithExpression)
-    lookup' sy (Mem map_ _) =
-      case Map.lookup sy map_ of
-        Just res -> return res
-        Nothing -> throw @"compilationError" VariableOutOfScope
+lookup :: HasMemoryErr m => Symbol -> m (Int, Types.Expression)
+lookup sy = do
+  Mem map _ <- get @"memory"
+  case Map.lookup sy map of
+    Just res -> return res
+    Nothing -> throw @"compilationError" Types.VariableOutOfScope
 
 write :: HasState "compilation" s m => s -> m s
-write exp =
-  do
-    put @"compilation" exp
-    return exp
+write exp = do
+  put @"compilation" exp
+  return exp
 
 read :: HasState "compilation" s m => m s
 read = get @"compilation"
 
-freshVars :: [Symbol] -> ArithmeticCircuitCompilation ()
+freshVars :: HasMemory m => [Symbol] -> m ()
 freshVars sys = modify @"memory" (freshVars' sys)
   where
     freshVars' :: [Symbol] -> Memory -> Memory
-    freshVars' vars (Mem map_ n) = Mem (map_ <> Map.fromList (zip vars (slots n))) (n + 1)
-    slots :: Int -> [(Int, ArithExpression)]
-    slots n = map (,NoExp) [n ..]
+    freshVars' vars (Mem map' n) =
+      Mem (map' <> Map.fromList (zip vars (slots n))) (n + 1)
+    --
+    slots :: Int -> [(Int, Types.Expression)]
+    slots n = fmap (,Types.NoExp) [n ..]

--- a/src/Juvix/Backends/ArithmeticCircuit/Compilation/Types.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Compilation/Types.hs
@@ -1,3 +1,7 @@
+-- |
+-- Provides the various types needed for the arithmetic circuit
+-- backend
+-- - Expression covers the gambit of arithmetic circuit expressions
 module Juvix.Backends.ArithmeticCircuit.Compilation.Types where
 
 import qualified Circuit
@@ -5,7 +9,6 @@ import qualified Circuit.Expr as Expr
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation as Par
 import qualified Juvix.Core.ErasedAnn as CoreErased
 import Juvix.Library
-import Numeric.Natural ()
 
 data PrimVal
   = Element Par.F
@@ -41,7 +44,7 @@ data CompilationError
   | TypeErrorApplicationNonFunction
   deriving (Eq, Show, Generic)
 
-data ArithExpression
+data Expression
   = BoolExp (Expr.Expr Circuit.Wire Par.F Bool)
   | FExp (Expr.Expr Circuit.Wire Par.F Par.F)
   | NoExp

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
@@ -44,6 +44,7 @@ instance FieldElements.FieldElement (Expr.Expr Arith.Wire) where
   neg = Expr.EUnOp Expr.UNeg
   eq = Lang.eq
   size _ = 254
+  intExp = undefined
 
 instance Booleans.Boolean (Expr.Expr Arith.Wire) Bool where
   and' = Lang.and_
@@ -87,8 +88,11 @@ typeOf (BoolVal x) =
   fmap boolTyToAll (Booleans.typeOf x)
 typeOf (FEVal x) =
   fmap feTyToAll (FieldElements.typeOf x)
-typeOf (Curried _ _) = Ty :| [Ty]
-typeOf Eq = BoolTy Booleans.Ty :| [FETy FieldElements.Ty, FETy FieldElements.Ty]
+typeOf (Curried _ _) =
+  Ty :| [Ty]
+typeOf Eq =
+  BoolTy Booleans.Ty :| [FETy FieldElements.Ty, FETy FieldElements.Ty]
+typeOf (IntegerVal _) = undefined
 
 apply :: Val -> Val -> Maybe Val
 apply (BoolVal x) (BoolVal y) =
@@ -111,10 +115,12 @@ parseVal lexer =
     <|> (feValToAll <$> FieldElements.parseVal lexer)
 
 reservedNames :: [String]
-reservedNames = Booleans.reservedNames <> FieldElements.reservedNames <> ["=="]
+reservedNames =
+  Booleans.reservedNames <> FieldElements.reservedNames <> ["=="]
 
 reservedOpNames :: [String]
-reservedOpNames = Booleans.reservedOpNames <> FieldElements.reservedOpNames <> ["=="]
+reservedOpNames =
+  Booleans.reservedOpNames <> FieldElements.reservedOpNames <> ["=="]
 
 t :: Parameterisation Ty Val
 t =

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
@@ -41,6 +41,9 @@ typeOf (Val _) = Ty :| []
 typeOf (Curried _ _) = Ty :| [Ty]
 typeOf Add = Ty :| [Ty, Ty]
 typeOf Mul = Ty :| [Ty, Ty]
+typeOf Neg = undefined
+typeOf IntExp = undefined
+typeOf Eq = undefined
 
 apply :: FieldElement e => Val (e f f) -> Val (e f f) -> Maybe (Val (e f f))
 apply Add (Val x) = pure (Curried Add x)
@@ -49,12 +52,12 @@ apply (Curried Add x) (Val y) = pure (Val (add x y))
 apply (Curried Mul x) (Val y) = pure (Val (mul x y))
 apply _ _ = Nothing
 
-parseTy :: Token.GenTokenParser String () Identity -> Parser Ty
+parseTy :: Token.TokenParser () -> Parser Ty
 parseTy lexer = do
   Token.reserved lexer "FieldElements"
   pure Ty
 
-parseVal :: Token.GenTokenParser String () Identity -> Parser (Val a)
+parseVal :: Token.TokenParser () -> Parser (Val a)
 parseVal lexer = undefined
 
 reservedNames :: [String]

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
@@ -28,47 +28,52 @@ class FieldElements.FieldElement e => FInteger (e :: * -> * -> *) i | i -> e whe
   exp :: e f i -> e f i -> e f f
   eq :: e f i -> e f i -> e f g
 
+type FieldT e i = (FieldElements.FieldElement e, FInteger e i)
+
 -- c: primitive constant and f: functions
 data Val f i where
-  Val :: (FieldElements.FieldElement e, FInteger e i) => e f i -> Val (e f i) i
-  Add :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i
-  Mul :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i
-  Neg :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i
-  Exp :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i
-  Eq :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i
-  Curried :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i -> e f i -> Val (e f b) i
+  Val :: FieldT e i => e f i -> Val (e f i) i
+  Add :: FieldT e i => Val (e f i) i
+  Mul :: FieldT e i => Val (e f i) i
+  Neg :: FieldT e i => Val (e f i) i
+  Exp :: FieldT e i => Val (e f i) i
+  Eq :: FieldT e i => Val (e f i) i
+  Curried :: FieldT e i => Val (e f i) i -> e f i -> Val (e f b) i
 
 typeOf :: Val f i -> NonEmpty Ty
 typeOf (Val _) = Ty :| []
 typeOf (Curried _ _) = Ty :| [Ty]
 typeOf Add = Ty :| [Ty, Ty]
 typeOf Mul = Ty :| [Ty, Ty]
+typeOf Exp = undefined
+typeOf Neg = undefined
+typeOf Eq = undefined
 
-apply :: (FieldElements.FieldElement e, FInteger e i) => Val (e f i) i -> Val (e f i) i -> Maybe (Val (e f i) i)
+apply :: FieldT e i => Val (e f i) i -> Val (e f i) i -> Maybe (Val (e f i) i)
 apply Add (Val x) = pure (Curried Add x)
 apply Mul (Val x) = pure (Curried Mul x)
 apply (Curried Add x) (Val y) = pure (Val (add x y))
 apply (Curried Mul x) (Val y) = pure (Val (mul x y))
 apply _ _ = Nothing
 
-parseTy :: Token.GenTokenParser String () Identity -> Parser Ty
+parseTy :: Token.TokenParser () -> Parser Ty
 parseTy lexer = do
   Token.reserved lexer "Int"
   pure Ty
 
-parseVal :: (FieldElements.FieldElement e, FInteger e i) => Token.GenTokenParser String () Identity -> Parser (Val (e f i) i)
+parseVal :: FieldT e i => Token.TokenParser () -> Parser (Val (e f i) i)
 parseVal lexer =
   parseNat lexer <|> parseAdd lexer <|> parseMul lexer
 
-parseNat :: (FieldElements.FieldElement e, FInteger e i) => Token.GenTokenParser String () Identity -> Parser (Val (e f i) i)
+parseNat :: FieldT e i => Token.TokenParser () -> Parser (Val (e f i) i)
 parseNat lexer = Val . fromPrim |<< Token.integer lexer
   where
     fromPrim = undefined
 
-parseAdd :: (FieldElements.FieldElement e, FInteger e i) => Token.GenTokenParser String () Identity -> Parser (Val (e f i) i)
+parseAdd :: FieldT e i => Token.TokenParser () -> Parser (Val (e f i) i)
 parseAdd lexer = Token.reserved lexer "+" >> pure Add
 
-parseMul :: (FieldElements.FieldElement e, FInteger e i) => Token.GenTokenParser String () Identity -> Parser (Val (e f i) i)
+parseMul :: FieldT e i => Token.TokenParser () -> Parser (Val (e f i) i)
 parseMul lexer = Token.reserved lexer "*" >> pure Mul
 
 reservedNames :: [String]
@@ -77,6 +82,6 @@ reservedNames = ["Int", "+", "-", "*"]
 reservedOpNames :: [String]
 reservedOpNames = []
 
-t :: (FieldElements.FieldElement e, FInteger e i) => Parameterisation Ty (Val (e f i) i)
+t :: FieldT e i => Parameterisation Ty (Val (e f i) i)
 t =
   Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames

--- a/src/Juvix/Backends/ArithmeticCircuit/ZKP.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/ZKP.hs
@@ -2,32 +2,33 @@
 
 module Juvix.Backends.ArithmeticCircuit.ZKP where
 
-import Circuit
-import Control.Monad.Random ()
-import qualified Data.Curve.Weierstrass.BN254 as G1
-import qualified Data.Curve.Weierstrass.BN254T as G2
-import Data.Field.Galois (rnd)
+import qualified Circuit
+import qualified Data.Field.Galois as Galois
 import qualified Data.Map as Map
-import Data.Pairing.BN254 (BN254, Fr, Pairing (..))
-import Fresh (evalFresh, fresh)
-import Juvix.Backends.ArithmeticCircuit.Compilation as Base
+import qualified Data.Pairing.BN254 as BN254
+import qualified Fresh
+import qualified Juvix.Backends.ArithmeticCircuit.Compilation as Base
+import Juvix.Library
 import qualified Protocol.Groth as Groth
-import Protolude
-import QAP
+import qualified QAP
 
 data SetupOutput
   = Setup
-      { randsetup :: Groth.RandomSetup Fr,
-        qap :: QAP Fr,
-        ref :: Groth.Reference (G1 BN254) (G2 BN254),
-        roots :: [[Fr]]
+      { randsetup :: Groth.RandomSetup BN254.Fr,
+        qap :: QAP.QAP BN254.Fr,
+        ref :: Groth.Reference (BN254.G1 BN254.BN254) (BN254.G2 BN254.BN254),
+        roots :: [[BN254.Fr]]
       }
 
-runSetup :: ArithCircuit Fr -> IO SetupOutput
+runSetup :: Circuit.ArithCircuit BN254.Fr -> IO SetupOutput
 runSetup program = do
-  let roots = evalFresh (generateRoots (fmap (fromIntegral . (+ 1)) fresh) program)
+  let roots =
+        Circuit.generateRoots (fmap (fromIntegral . succ) Fresh.fresh) program
+          |> Fresh.evalFresh
   let qap = QAP.arithCircuitToQAP roots program
-  rndSetup <- Groth.generateRandomSetup rnd
+  --
+  rndSetup <- Groth.generateRandomSetup Galois.rnd
+  --
   let (ref, _) = Groth.setup rndSetup qap
   return $
     Setup
@@ -37,18 +38,36 @@ runSetup program = do
         roots = roots
       }
 
-runProve :: ArithCircuit Fr -> [(Int, Fr)] -> SetupOutput -> IO (Groth.Proof (G1 BN254) (G2 BN254))
+runProve ::
+  Circuit.ArithCircuit BN254.Fr ->
+  [(Int, BN254.Fr)] ->
+  SetupOutput ->
+  IO (Groth.Proof (BN254.G1 BN254.BN254) (BN254.G2 BN254.BN254))
 runProve program inputs Setup {qap, ref} = do
-  rndProver <- Groth.generateRandomProver rnd
-  return $ Groth.prove rndProver program qap (Groth.refP ref) (Map.fromList inputs)
+  rndProver <- Groth.generateRandomProver Galois.rnd
+  pure $ Groth.prove rndProver program qap (Groth.refP ref) (Map.fromList inputs)
 
-runVerify :: [(Int, Fr)] -> SetupOutput -> Groth.Proof (G1 BN254) (G2 BN254) -> Bool
-runVerify inputs Setup {ref} proof = Groth.verify (Groth.refV ref) (Map.fromList inputs) proof
+runVerify ::
+  [(Int, BN254.Fr)] ->
+  SetupOutput ->
+  Groth.Proof (BN254.G1 BN254.BN254) (BN254.G2 BN254.BN254) ->
+  Bool
+runVerify inputs Setup {ref} proof =
+  Groth.verify (Groth.refV ref) (Map.fromList inputs) proof
 
-verify :: [(Int, Fr)] -> SetupOutput -> Groth.Proof (G1 BN254) (G2 BN254) -> Bool
+verify ::
+  [(Int, BN254.Fr)] ->
+  SetupOutput ->
+  Groth.Proof (BN254.G1 BN254.BN254) (BN254.G2 BN254.BN254) ->
+  Bool
 verify = runVerify
 
-prove :: Base.Term -> Base.Type -> [(Int, Fr)] -> SetupOutput -> IO (Groth.Proof (G1 BN254) (G2 BN254))
+prove ::
+  Base.Term ->
+  Base.Type ->
+  [(Int, BN254.Fr)] ->
+  SetupOutput ->
+  IO (Groth.Proof (BN254.G1 BN254.BN254) (BN254.G2 BN254.BN254))
 prove term ty params stp =
   case Base.compile term ty of
     (Right _, program) -> runProve program params stp


### PR DESCRIPTION
Namely I've

1. Created type alises
2. made sure code become 80 characters per line or less
3. abstracted some patterns
4. used the capability signature instead of the type itself
5. Qualified all imports modulo library and parser
6. Making things rely more on exhaustion than catchalls
    -   I can do this better
7. Replacing unexhaustive matches with undefineds