### PR TITLE
Core to Michelson (sans datatypes)

### DIFF
--- a/app/Compile.hs
+++ b/app/Compile.hs
@@ -45,7 +45,7 @@ compile :: FilePath -> FilePath -> Backend -> IO ()
 compile fin fout backend = do
   _term <- typecheck fin backend
   -- TODO: Annotated version.
-  let (res, _logs) = M.compileContract undefined undefined
+  let (res, _logs) = M.compileContract undefined
   case res of
     Left err -> do
       T.putStrLn (show err)

--- a/package.yaml
+++ b/package.yaml
@@ -167,6 +167,7 @@ library:
     - Juvix.Frontend.Lexer
     - Juvix.Frontend.Parser
     - Juvix.Core
+    - Juvix.Core.Pipeline
     - Juvix.Core.Common.Context
     - Juvix.Core.HR
     - Juvix.Core.HRAnn
@@ -270,7 +271,6 @@ library:
   other-modules:
     - Juvix.Interpreter.InteractionNet.NodeInterface
     - Juvix.Core.Translate
-    - Juvix.Core.Pipeline
     - Juvix.Core.Utility
     - Juvix.Core.IR.Types
     - Juvix.Core.IR.Types.Base
@@ -278,14 +278,18 @@ library:
     - Juvix.Core.IR.Evaluator
     - Juvix.Core.HR.Parser
     - Juvix.Core.HR.Types
+    - Juvix.Core.HR.Extend
     - Juvix.Core.HRAnn.Types
     - Juvix.Core.HRAnn.Erasure
+    - Juvix.Core.HRAnn.Extend
     - Juvix.Core.IRAnn.Types
     - Juvix.Core.IRAnn.Erasure
     - Juvix.Core.ErasedAnn.Types
     - Juvix.Core.ErasedAnn.Erasure
     - Juvix.Core.ErasedAnn.Prim
+    - Juvix.Core.ErasedAnn.Conversion
     - Juvix.Core.Erased.Types.Base
+    - Juvix.Core.Erased.Extend
     - Juvix.Core.IR.Typechecker.Types
     - Juvix.Core.IR.Typechecker.Env
     - Juvix.Core.Parameterisation

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns -Wwarn=missing-methods #-}
+
 module Juvix.Backends.ArithmeticCircuit.Parameterisation where
 
 import qualified Circuit.Arithmetic as Arith

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 module Juvix.Backends.ArithmeticCircuit.Parameterisation.Booleans where
 
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements as FieldElements

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 module Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements where
 
 import Juvix.Core.Types hiding

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 module Juvix.Backends.ArithmeticCircuit.Parameterisation.Integers where
 
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements as FieldElements

--- a/src/Juvix/Backends/Michelson/Compilation.hs
+++ b/src/Juvix/Backends/Michelson/Compilation.hs
@@ -31,10 +31,9 @@ untypedContractToSourceLine c = L.toStrict (M.printUntypedContract True c)
 
 compileContract ::
   Term ->
-  Type ->
   (Either DSL.CompError (M.Contract' M.ExpandedOp, M.SomeContract), [CompilationLog])
-compileContract term ty =
-  let (ret, env) = DSL.execMichelson (compileToMichelsonContract term ty)
+compileContract term =
+  let (ret, env) = DSL.execMichelson (compileToMichelsonContract term)
    in (ret, DSL.compilationLog env)
 
 compileExpr :: Term -> (Either DSL.CompError EmptyInstr, [CompilationLog])
@@ -45,9 +44,9 @@ compileExpr term =
 compileToMichelsonContract ::
   DSL.Reduction m =>
   Term ->
-  Type ->
   m (M.Contract' M.ExpandedOp, M.SomeContract)
-compileToMichelsonContract term ty = do
+compileToMichelsonContract term = do
+  let Ann.Ann _ ty _ = term
   michelsonTy <- DSL.typeToPrimType ty
   case michelsonTy of
     M.Type (M.TLambda argTy@(M.Type (M.TPair _ _ paramTy storageTy) _) _) _ -> do

--- a/src/Juvix/Backends/Michelson/DSL/Instructions.hs
+++ b/src/Juvix/Backends/Michelson/DSL/Instructions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 -- |
 -- - This module serves as a lower layer DSL that is just a binding
 --   over the untyped instruction bindings

--- a/src/Juvix/Backends/Michelson/DSL/InstructionsEff.hs
+++ b/src/Juvix/Backends/Michelson/DSL/InstructionsEff.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 -- |
 -- - This module includes a higher level DSL which each instruction
 --   has a stack effect

--- a/src/Juvix/Backends/Michelson/DSL/InstructionsEff.hs
+++ b/src/Juvix/Backends/Michelson/DSL/InstructionsEff.hs
@@ -771,7 +771,7 @@ mustLookupType sym = do
   stack <- get @"stack"
   case VStack.lookupType sym stack of
     Just ty -> pure ty
-    Nothing -> throw @"compilationError" (Types.InternalFault "must be able to find type")
+    Nothing -> throw @"compilationError" (Types.InternalFault ("must be able to find type for symbol: " <> show sym))
 
 -- TODO ∷ figure out why we remove some of the bodies effects
 promoteLambda :: Env.Reduction m => Env.Curried -> m [Instr.ExpandedOp]

--- a/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -31,6 +31,7 @@ import Prelude (String)
 -- TODO: Add dependent functions for pair, fst, snd, etc.
 typeOf :: PrimVal -> NonEmpty PrimTy
 typeOf (Constant v) = PrimTy (M.Type (constType v) "") :| []
+typeOf AddI = PrimTy (M.Type M.TInt "") :| [PrimTy (M.Type M.TInt ""), PrimTy (M.Type M.TInt "")]
 
 -- constructTerm ∷ PrimVal → PrimTy
 -- constructTerm (PrimConst v) = (v, Usage.Omega, PrimTy (M.Type (constType v) ""))

--- a/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 module Juvix.Backends.Michelson.Parameterisation
   ( module Juvix.Backends.Michelson.Parameterisation,
     module Juvix.Backends.Michelson.Compilation.Types,

--- a/src/Juvix/Core/Erased/Extend.hs
+++ b/src/Juvix/Core/Erased/Extend.hs
@@ -1,0 +1,26 @@
+module Juvix.Core.Erased.Extend where
+
+import qualified Juvix.Core.HRAnn.Extend as HR
+import qualified Juvix.Core.IR.Types as IR
+import Juvix.Core.IR.Types.Base
+import Juvix.Library
+
+extTerm = HR.extTerm
+
+extElim = HR.extElim
+
+extValue = \_ _ -> defaultExtValue
+
+extNeutral = \_ _ -> defaultExtNeutral
+
+extDatatype = \_ _ -> defaultExtDatatype
+
+extDataArg = \_ _ -> defaultExtDataArg
+
+extDataCon = \_ _ -> defaultExtDataCon
+
+extFunction = \_ _ -> defaultExtFunction
+
+extFunClause = \_ _ -> defaultExtFunClause
+
+extPattern = \_ _ -> defaultExtPattern

--- a/src/Juvix/Core/Erased/Types.hs
+++ b/src/Juvix/Core/Erased/Types.hs
@@ -32,10 +32,6 @@ extendTerm "Term" [] [t|T|] (\_ -> defaultExtTerm)
 
 extendType "Type" [] [t|T|] (\_ -> defaultExtType)
 
--- IR.extendTerm "Term" [] [t|T|] extTerm
-
--- IR.extendElim "Elim" [] [t|T|] extElim
-
 IR.extendValue "Value" [] [t|T|] extValue
 
 IR.extendNeutral "Neutral" [] [t|T|] extNeutral

--- a/src/Juvix/Core/Erased/Types.hs
+++ b/src/Juvix/Core/Erased/Types.hs
@@ -3,19 +3,56 @@ module Juvix.Core.Erased.Types
     Term' (..),
     Type' (..),
     TypeAssignment',
-    NoExt,
   )
 where
 
+import Juvix.Core.Erased.Extend
 import Juvix.Core.Erased.Types.Base
-import Juvix.Core.IR.Types (NoExt)
-import Juvix.Library
+import Juvix.Core.HRAnn.Types (Annotation (..), AppAnnotation (..), BindAnnotation (..))
+import qualified Juvix.Core.IR.Types.Base as IR
+import Juvix.Core.IR.Types.Base hiding
+  ( Term' (..),
+    defaultExtTerm,
+    extDataArg,
+    extDataCon,
+    extDatatype,
+    extFunClause,
+    extFunction,
+    extPattern,
+    extTerm,
+    extendTerm,
+  )
+import qualified Juvix.Core.Usage as Usage
+import Juvix.Library hiding (Type)
+import qualified Juvix.Library.HashMap as Map
 
-extendTerm "Term" [] [t|NoExt|] $ \_ -> defaultExtTerm
+data T
 
-extendType "Type" [] [t|NoExt|] $ \_ -> defaultExtType
+extendTerm "Term" [] [t|T|] (\_ -> defaultExtTerm)
 
-type TypeAssignment primTy = TypeAssignment' NoExt primTy
+extendType "Type" [] [t|T|] (\_ -> defaultExtType)
+
+-- IR.extendTerm "Term" [] [t|T|] extTerm
+
+-- IR.extendElim "Elim" [] [t|T|] extElim
+
+IR.extendValue "Value" [] [t|T|] extValue
+
+IR.extendNeutral "Neutral" [] [t|T|] extNeutral
+
+IR.extendDatatype "Datatype" [] [t|T|] extDatatype
+
+IR.extendDataArg "DataArg" [] [t|T|] extDataArg
+
+IR.extendDataCon "DataCon" [] [t|T|] extDataCon
+
+IR.extendFunction "Function" [] [t|T|] extFunction
+
+IR.extendFunClause "FunClause" [] [t|T|] extFunClause
+
+IR.extendPattern "Pattern" [] [t|T|] extPattern
+
+type TypeAssignment primTy = TypeAssignment' T primTy
 
 data EvaluationError primVal
   = PrimitiveApplicationError primVal primVal

--- a/src/Juvix/Core/ErasedAnn.hs
+++ b/src/Juvix/Core/ErasedAnn.hs
@@ -1,8 +1,8 @@
 module Juvix.Core.ErasedAnn
   ( module Juvix.Core.ErasedAnn.Types,
-    module Juvix.Core.ErasedAnn.Erasure,
+    module Juvix.Core.ErasedAnn.Conversion,
   )
 where
 
-import Juvix.Core.ErasedAnn.Erasure
+import Juvix.Core.ErasedAnn.Conversion
 import Juvix.Core.ErasedAnn.Types

--- a/src/Juvix/Core/ErasedAnn/Conversion.hs
+++ b/src/Juvix/Core/ErasedAnn/Conversion.hs
@@ -1,0 +1,34 @@
+module Juvix.Core.ErasedAnn.Conversion where
+
+import Juvix.Core.ErasedAnn.Types
+import qualified Juvix.Core.Erasure.Types as E
+import qualified Juvix.Core.Usage as Usage
+import Juvix.Library hiding (Type)
+
+convertTerm :: forall primTy primVal m. (Monad m) => E.Term primTy primVal -> Usage.T -> m (AnnTerm primTy primVal)
+convertTerm term usage = do
+  let ty = E.getType term
+  ty' <- convertType ty
+  case term of
+    E.Var sym _ -> pure (Ann usage ty' (Var sym))
+    E.Prim p _ -> pure (Ann usage ty' (Prim p))
+    E.Lam sym body _ -> do
+      -- TODO: Is this the right usage?
+      -- TODO: Deal with arguments, captures.
+      body <- convertTerm body usage
+      pure (Ann usage ty' (LamM [] [sym] body))
+    E.App f a _ -> do
+      f <- convertTerm f usage
+      a <- convertTerm a usage
+      -- TODO: Deal with multi-arg application.
+      pure (Ann usage ty' (AppM f [a]))
+
+convertType :: forall primTy primVal m. (Monad m) => E.Type primTy -> m (Type primTy primVal)
+convertType ty =
+  case ty of
+    E.SymT s -> pure (SymT s)
+    E.PrimTy p -> pure (PrimTy p)
+    E.Pi u a r -> do
+      a <- convertType a
+      r <- convertType r
+      pure (Pi u a r)

--- a/src/Juvix/Core/ErasedAnn/Conversion.hs
+++ b/src/Juvix/Core/ErasedAnn/Conversion.hs
@@ -1,31 +1,56 @@
 module Juvix.Core.ErasedAnn.Conversion where
 
+import qualified Juvix.Core.Erased as Erased
 import Juvix.Core.ErasedAnn.Types
 import qualified Juvix.Core.Erasure.Types as E
+import qualified Juvix.Core.Types as Types
 import qualified Juvix.Core.Usage as Usage
 import Juvix.Library hiding (Type)
 
-convertTerm :: forall primTy primVal m. (Monad m) => E.Term primTy primVal -> Usage.T -> m (AnnTerm primTy primVal)
+free :: forall primTy primVal. E.Term primTy primVal -> [Symbol]
+free = Erased.free . E.eraseAnn
+
+convertTerm :: forall primTy primVal compErr m. (HasThrow "error" (Types.PipelineError primTy primVal compErr) m) => E.Term primTy primVal -> Usage.T -> m (AnnTerm primTy primVal)
 convertTerm term usage = do
   let ty = E.getType term
   ty' <- convertType ty
   case term of
     E.Var sym _ -> pure (Ann usage ty' (Var sym))
     E.Prim p _ -> pure (Ann usage ty' (Prim p))
+    E.Let sym bind body (bindTy, _) -> do
+      -- Calculate captures.
+      let captures = free (E.Lam sym body undefined)
+      -- TODO: Is this the right usage?
+      bind <- convertTerm bind usage
+      body <- convertTerm body usage
+      bindTy <- convertType bindTy
+      -- TODO: Eventually add `let` to Michelson, probably, instead of this conversion.
+      let lamTy = Pi usage bindTy ty'
+          lam = Ann usage lamTy (LamM captures [sym] body)
+      pure (Ann usage ty' (AppM lam [bind]))
     E.Lam sym body _ -> do
       -- TODO: Is this the right usage?
-      -- TODO: Deal with arguments, captures.
       body <- convertTerm body usage
-      pure (Ann usage ty' (LamM [] [sym] body))
+      case body of
+        -- Combine nested lambdas into multi-argument function.
+        Ann _ _ (LamM cap' arg' body') ->
+          pure (Ann usage ty' (LamM cap' (sym : arg') body'))
+        _ ->
+          pure (Ann usage ty' (LamM (free term) [sym] body))
     E.App f a _ -> do
       f <- convertTerm f usage
       a <- convertTerm a usage
-      -- TODO: Deal with multi-arg application.
-      pure (Ann usage ty' (AppM f [a]))
+      case f of
+        -- Combine nested application into multi-argument application.
+        Ann _ _ (AppM f' a') ->
+          pure (Ann usage ty' (AppM f' (a' <> [a])))
+        _ ->
+          pure (Ann usage ty' (AppM f [a]))
 
-convertType :: forall primTy primVal m. (Monad m) => E.Type primTy -> m (Type primTy primVal)
+convertType :: forall primTy primVal compErr m. (HasThrow "error" (Types.PipelineError primTy primVal compErr) m) => E.Type primTy -> m (Type primTy primVal)
 convertType ty =
   case ty of
+    E.Star u -> pure (Star u)
     E.SymT s -> pure (SymT s)
     E.PrimTy p -> pure (PrimTy p)
     E.Pi u a r -> do

--- a/src/Juvix/Core/ErasedAnn/Prim.hs
+++ b/src/Juvix/Core/ErasedAnn/Prim.hs
@@ -1,7 +1,7 @@
 -- |
 -- - This module represents the type which will be sent to the
---   paramiterization
--- - the =Take= type is what a paramiterization will take coming in
+--   parameterisation
+-- - the =Take= type is what a parameterisation will take coming in
 -- - the =Return= type is what will be handed back to Core to evaluate
 --   and decide on the next steps. If this is a =Left= type checking
 --   has failed, if it's a =Right= then type checking will continue

--- a/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/src/Juvix/Core/Erasure/Algorithm.hs
@@ -44,9 +44,12 @@ eraseTerm (Typed.Let π b t anns) = do
   if π == mempty
     then pure t
     else do
-      let ty = IR.annType $ IR.baResAnn anns
+      let exprTy = IR.annType $ IR.baResAnn anns
+          bindTy = IR.annType $ IR.baBindAnn anns
       b <- eraseElim b
-      Erasure.Let x b t <$> eraseType ty
+      bindTy <- eraseType bindTy
+      exprTy <- eraseType exprTy
+      pure (Erasure.Let x b t (bindTy, exprTy))
 eraseTerm (Typed.Elim e _) = eraseElim e
 
 eraseElim ::

--- a/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/src/Juvix/Core/Erasure/Algorithm.hs
@@ -93,9 +93,11 @@ eraseType (IR.VStar i) = do
 eraseType (IR.VPrimTy t) = do
   pure $ Erasure.PrimTy t
 eraseType (IR.VPi π a b) = do
-  -- FIXME dependency
-  Erasure.Pi π <$> eraseType a
-    <*> withName \_ -> eraseType b
+  if π == mempty
+    then eraseType b
+    else-- FIXME dependency
+    Erasure.Pi π <$> eraseType a
+      <*> withName \_ -> eraseType b
 eraseType v@(IR.VLam _) = do
   throwEra $ Erasure.UnsupportedTypeV v
 eraseType (IR.VNeutral n) = do

--- a/src/Juvix/Core/HR/Extend.hs
+++ b/src/Juvix/Core/HR/Extend.hs
@@ -1,0 +1,24 @@
+module Juvix.Core.HR.Extend where
+
+import qualified Juvix.Core.IR.Types.Base
+import qualified Juvix.Core.IR.Types.Base as IR
+import Juvix.Library
+
+extTerm =
+  \_primTy _primVal ->
+    IR.defaultExtTerm
+      { IR.nameLam = "Lam0",
+        IR.typeLam = Just [[t|Symbol|]],
+        IR.namePi = "Pi0",
+        IR.typePi = Just [[t|Symbol|]],
+        IR.nameLet = "Let0",
+        IR.typeLet = Just [[t|Symbol|]]
+      }
+
+extElim =
+  \_primTy _primVal ->
+    IR.defaultExtElim
+      { IR.typeBound = Nothing,
+        IR.typeFree = Nothing,
+        IR.typeElimX = [("Var", [[t|Symbol|]])]
+      }

--- a/src/Juvix/Core/HR/Types.hs
+++ b/src/Juvix/Core/HR/Types.hs
@@ -1,21 +1,13 @@
 module Juvix.Core.HR.Types where
 
-import qualified Juvix.Core.IR.Types.Base
+import Juvix.Core.HR.Extend
+import Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
 import Juvix.Library
 
 data T
 
-IR.extendTerm "Term" [] [t|T|] $
-  \_primTy _primVal ->
-    IR.defaultExtTerm
-      { IR.nameLam = "Lam0",
-        IR.typeLam = Just [[t|Symbol|]],
-        IR.namePi = "Pi0",
-        IR.typePi = Just [[t|Symbol|]],
-        IR.nameLet = "Let0",
-        IR.typeLet = Just [[t|Symbol|]]
-      }
+IR.extendTerm "Term" [] [t|T|] extTerm
 
 -- TODO allow extendTerm to reorder fields?
 pattern Lam x t = Lam0 t x
@@ -26,10 +18,4 @@ pattern Let π x l b = Let0 π l b x
 
 {-# COMPLETE Star, PrimTy, Pi, Lam, Let, Elim #-}
 
-IR.extendElim "Elim" [] [t|T|] $
-  \_primTy _primVal ->
-    IR.defaultExtElim
-      { IR.typeBound = Nothing,
-        IR.typeFree = Nothing,
-        IR.typeElimX = [("Var", [[t|Symbol|]])]
-      }
+IR.extendElim "Elim" [] [t|T|] extElim

--- a/src/Juvix/Core/HRAnn/Extend.hs
+++ b/src/Juvix/Core/HRAnn/Extend.hs
@@ -1,0 +1,57 @@
+module Juvix.Core.HRAnn.Extend where
+
+import qualified Extensible as Ext
+import qualified Juvix.Core.IR.Types.Base
+import qualified Juvix.Core.IR.Types.Base as IR
+import qualified Juvix.Core.Usage as Usage
+import Juvix.Library
+
+data T
+
+data Annotation primTy primVal
+  = Annotation
+      { usageAnn :: Usage.T,
+        typeAnn :: IR.Term' T primTy primVal
+      }
+
+data BindAnnotation primTy primVal
+  = BindAnnotation
+      { bindName :: Symbol,
+        bindAnn :: {-# UNPACK #-} !(Annotation primTy primVal)
+      }
+
+data LetAnnotation primTy primVal
+  = LetAnnotation
+      { letName :: Symbol,
+        letType :: IR.Term' T primTy primVal
+      }
+
+-- TODO: add combinators to @extensible-data@ for pairing like this
+extTerm =
+  \primTy primVal ->
+    IR.defaultExtTerm
+      { IR.nameLam = "Lam0",
+        IR.typeLam = Just [[t|BindAnnotation $primTy $primVal|]],
+        IR.namePi = "Pi0",
+        IR.typePi = Just [[t|Symbol|]],
+        IR.nameLet = "Let0",
+        IR.typeLet = Just [[t|LetAnnotation $primTy $primVal|]],
+        IR.nameElim = "Elim0",
+        IR.typeElim = Just [[t|Annotation $primTy $primVal|]]
+      }
+
+data AppAnnotation primTy primVal
+  = AppAnnotation
+      { funAnn :: {-# UNPACK #-} !(Annotation primTy primVal),
+        argAnn :: {-# UNPACK #-} !(Annotation primTy primVal)
+      }
+
+extElim =
+  \primTy primVal ->
+    IR.defaultExtElim
+      { IR.typeBound = Nothing,
+        IR.typeFree = Nothing,
+        IR.typeElimX = [("Var", [[t|Symbol|]])],
+        IR.nameApp = "App0",
+        IR.typeApp = Just [[t|AppAnnotation $primTy $primVal|]]
+      }

--- a/src/Juvix/Core/HRAnn/Types.hs
+++ b/src/Juvix/Core/HRAnn/Types.hs
@@ -1,44 +1,18 @@
-module Juvix.Core.HRAnn.Types where
+module Juvix.Core.HRAnn.Types
+  ( module Juvix.Core.HRAnn.Types,
+    module Juvix.Core.HRAnn.Extend,
+  )
+where
 
 import qualified Extensible as Ext
+import Juvix.Core.HRAnn.Extend
 import qualified Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
 import qualified Juvix.Core.Usage as Usage
 import Juvix.Library
 
-data T
-
-data Annotation primTy primVal
-  = Annotation
-      { usageAnn :: Usage.T,
-        typeAnn :: IR.Term' T primTy primVal
-      }
-
-data BindAnnotation primTy primVal
-  = BindAnnotation
-      { bindName :: Symbol,
-        bindAnn :: {-# UNPACK #-} !(Annotation primTy primVal)
-      }
-
-data LetAnnotation primTy primVal
-  = LetAnnotation
-      { letName :: Symbol,
-        letType :: IR.Term' T primTy primVal
-      }
-
 -- TODO: add combinators to @extensible-data@ for pairing like this
-IR.extendTerm "Term" [] [t|T|] $
-  \primTy primVal ->
-    IR.defaultExtTerm
-      { IR.nameLam = "Lam0",
-        IR.typeLam = Just [[t|BindAnnotation $primTy $primVal|]],
-        IR.namePi = "Pi0",
-        IR.typePi = Just [[t|Symbol|]],
-        IR.nameLet = "Let0",
-        IR.typeLet = Just [[t|LetAnnotation $primTy $primVal|]],
-        IR.nameElim = "Elim0",
-        IR.typeElim = Just [[t|Annotation $primTy $primVal|]]
-      }
+IR.extendTerm "Term" [] [t|T|] extTerm
 
 -- TODO allow extendTerm to reorder fields?
 pattern Lam π x s t = Lam0 t (BindAnnotation x (Annotation π s))
@@ -51,21 +25,7 @@ pattern Elim π s t = Elim0 s (Annotation π t)
 
 {-# COMPLETE Star, PrimTy, Pi, Lam, Let, Elim #-}
 
-data AppAnnotation primTy primVal
-  = AppAnnotation
-      { funAnn :: {-# UNPACK #-} !(Annotation primTy primVal),
-        argAnn :: {-# UNPACK #-} !(Annotation primTy primVal)
-      }
-
-IR.extendElim "Elim" [] [t|T|] $
-  \primTy primVal ->
-    IR.defaultExtElim
-      { IR.typeBound = Nothing,
-        IR.typeFree = Nothing,
-        IR.typeElimX = [("Var", [[t|Symbol|]])],
-        IR.nameApp = "App0",
-        IR.typeApp = Just [[t|AppAnnotation $primTy $primVal|]]
-      }
+IR.extendElim "Elim" [] [t|T|] extElim
 
 pattern App π s ts ρ t tt =
   App0 s t (AppAnnotation (Annotation π ts) (Annotation ρ tt))

--- a/src/Juvix/Interpreter/InteractionNet.hs
+++ b/src/Juvix/Interpreter/InteractionNet.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+
 module Juvix.Interpreter.InteractionNet
   ( module Juvix.Interpreter.InteractionNet.Parser,
     module Juvix.Interpreter.InteractionNet.Translation,

--- a/test/Backends/Michelson.hs
+++ b/test/Backends/Michelson.hs
@@ -22,7 +22,7 @@ import Prelude (show)
 
 runContract :: Term -> Type -> Either DSL.CompError (Contract' ExpandedOp)
 runContract term ty =
-  fst (compileContract term ty) >>| fst
+  fst (compileContract term) >>| fst
 
 runExpr :: Term -> Either DSL.CompError EmptyInstr
 runExpr term =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,13 +5,13 @@ import qualified Backends.LLVM as LLVM
 import qualified Backends.Michelson as Michelson
 import qualified CoreConv
 import qualified CoreParser
-import qualified Pipeline
 import qualified CoreTypechecker
 import qualified EAC2
 import qualified Erasure
 import qualified Frontend
 import qualified FrontendDesugar
 import Juvix.Library hiding (identity)
+import qualified Pipeline
 import qualified Test.Tasty as T
 import qualified Test.Tasty.QuickCheck as T
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,6 +5,7 @@ import qualified Backends.LLVM as LLVM
 import qualified Backends.Michelson as Michelson
 import qualified CoreConv
 import qualified CoreParser
+import qualified Pipeline
 import qualified CoreTypechecker
 import qualified EAC2
 import qualified Erasure
@@ -23,6 +24,12 @@ coreTests =
       CoreParser.coreParser
     ]
 
+pipelineTests :: T.TestTree
+pipelineTests =
+  T.testGroup
+    "Pipeline tests"
+    Pipeline.tests
+
 backendTests :: T.TestTree
 backendTests =
   T.testGroup
@@ -40,6 +47,7 @@ allCheckedTests =
   T.testGroup
     "All tests that are checked"
     [ coreTests,
+      pipelineTests,
       backendTests,
       frontEndTests,
       translationPasses,

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -67,10 +67,14 @@ exec (EnvE env) param globals = do
   (ret, env) <- runStateT (runExceptT env) (Env param [] globals)
   pure (ret, log env)
 
+type AnnTuple = (HR.Term PrimTy PrimVal, Usage.T, HR.Term PrimTy PrimVal)
+
+type Globals = Typed.Globals PrimTy PrimVal
+
 shouldCompileTo ::
   String ->
-  (HR.Term PrimTy PrimVal, Usage.T, HR.Term PrimTy PrimVal) ->
-  Typed.Globals PrimTy PrimVal ->
+  AnnTuple ->
+  Globals ->
   EmptyInstr ->
   T.TestTree
 shouldCompileTo name (term, usage, ty) globals instr =
@@ -80,8 +84,8 @@ shouldCompileTo name (term, usage, ty) globals instr =
 
 shouldCompileToContract ::
   String ->
-  (HR.Term PrimTy PrimVal, Usage.T, HR.Term PrimTy PrimVal) ->
-  Typed.Globals PrimTy PrimVal ->
+  AnnTuple ->
+  Globals ->
   Text ->
   T.TestTree
 shouldCompileToContract name (term, usage, ty) globals contract =

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -94,7 +94,7 @@ toMichelson term usage ty globals = do
 
 tests :: [T.TestTree]
 tests =
-  [ test_constant ]
+  [test_constant]
 
 test_constant :: T.TestTree
 test_constant =

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -1,0 +1,117 @@
+module Pipeline where
+
+import Juvix.Backends.Michelson.Compilation.Types
+import Juvix.Backends.Michelson.Parameterisation
+import qualified Juvix.Core.HR as HR
+import qualified Juvix.Core.IR as IR
+import qualified Juvix.Core.IR.Typechecker as Typed
+import qualified Juvix.Core.Pipeline as P
+import qualified Juvix.Core.Types as Core
+import qualified Juvix.Core.Usage as Usage
+import Juvix.Library hiding (bool, identity, log)
+import qualified Michelson.Typed as MT
+import qualified Michelson.Untyped as M
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import Prelude (String)
+
+data Env primTy primVal
+  = Env
+      { parameterisation :: Core.Parameterisation primTy primVal,
+        log :: [Core.PipelineLog primTy primVal],
+        globals :: IR.Globals primTy primVal
+      }
+  deriving (Generic)
+
+type EnvExecAlias primTy primVal compErr =
+  ExceptT
+    (Core.PipelineError primTy primVal compErr)
+    (StateT (Env primTy primVal) IO)
+
+newtype EnvExec primTy primVal compErr a
+  = EnvE (EnvExecAlias primTy primVal compErr a)
+  deriving (Functor, Applicative, Monad, MonadIO)
+  deriving
+    ( HasSink "log" [Core.PipelineLog primTy primVal],
+      HasWriter "log" [Core.PipelineLog primTy primVal]
+    )
+    via WriterField "log" (EnvExecAlias primTy primVal compErr)
+  deriving
+    ( HasReader "parameterisation" (Core.Parameterisation primTy primVal),
+      HasSource "parameterisation" (Core.Parameterisation primTy primVal)
+    )
+    via ReaderField "parameterisation" (EnvExecAlias primTy primVal compErr)
+  deriving
+    ( HasState "globals" (IR.Globals primTy primVal),
+      HasSource "globals" (IR.Globals primTy primVal),
+      HasSink "globals" (IR.Globals primTy primVal)
+    )
+    via StateField "globals" (EnvExecAlias primTy primVal compErr)
+  deriving
+    (HasReader "globals" (IR.Globals primTy primVal))
+    via ReaderField "globals" (EnvExecAlias primTy primVal compErr)
+  deriving
+    (HasThrow "error" (Core.PipelineError primTy primVal compErr))
+    via MonadError (EnvExecAlias primTy primVal compErr)
+
+exec ::
+  EnvExec primTy primVal CompErr a ->
+  Core.Parameterisation primTy primVal ->
+  IR.Globals primTy primVal ->
+  IO
+    ( Either (Core.PipelineError primTy primVal CompErr) a,
+      [Core.PipelineLog primTy primVal]
+    )
+exec (EnvE env) param globals = do
+  (ret, env) <- runStateT (runExceptT env) (Env param [] globals)
+  pure (ret, log env)
+
+shouldCompileTo ::
+  String ->
+  (HR.Term PrimTy PrimVal, Usage.T, HR.Term PrimTy PrimVal) ->
+  Typed.Globals PrimTy PrimVal ->
+  EmptyInstr ->
+  T.TestTree
+shouldCompileTo name (term, usage, ty) globals instr =
+  T.testCase name $ do
+    res <- toMichelson term usage ty globals
+    show res T.@=? (show (Right instr :: Either String EmptyInstr) :: String)
+
+toMichelson ::
+  HR.Term PrimTy PrimVal ->
+  Usage.T ->
+  HR.Term PrimTy PrimVal ->
+  Typed.Globals PrimTy PrimVal ->
+  IO (Either String EmptyInstr)
+toMichelson term usage ty globals = do
+  (res, _) <- exec (P.coreToMichelson term usage ty) michelson globals
+  pure $ case res of
+    Right r ->
+      case r of
+        Right e -> Right e
+        Left err -> Left (show err)
+    Left err -> Left (show err)
+
+tests :: [T.TestTree]
+tests =
+  [ test_constant ]
+
+test_constant :: T.TestTree
+test_constant =
+  shouldCompileTo
+    "constant"
+    (twoTerm, Usage.Omega, intTy)
+    emptyGlobals
+    (EmptyInstr (MT.Seq (MT.Nested (MT.PUSH (MT.VInt 2))) MT.Nop))
+
+twoTerm :: HR.Term PrimTy PrimVal
+twoTerm = HR.Elim (HR.Prim (Constant (M.ValueInt 2)))
+
+emptyGlobals :: Typed.Globals PrimTy PrimVal
+emptyGlobals = mempty
+
+intTy :: HR.Term PrimTy PrimVal
+intTy = HR.PrimTy int
+
+int :: PrimTy
+int = PrimTy (M.Type M.TInt "")


### PR DESCRIPTION
Split out from the work in https://github.com/metastatedev/juvix/pull/407 for ease of review & integration.

This PR does the following:
- Hooks up the pipeline so that core can be taken all the way to Michelson
- Adds a conversion function from `Erased` types to `ErasedAnn` types
- Adds an annotation for the bind in `let` so that this can be passed down the pipeline
- Fixes a bug in erasure where `Pi` types with zero-usage arguments were not properly erased
- Adds some simple test-cases of type-checking, erasing, and compiling HR terms to Michelson

This does _not_ yet add datatype compilation, that will be a separate PR.