### PR TITLE
Clean up warnings.

### DIFF
--- a/app/Compile.hs
+++ b/app/Compile.hs
@@ -6,7 +6,6 @@ import qualified Data.Text.IO as T
 import qualified Juvix.Backends.Michelson.Compilation as M
 import qualified Juvix.Backends.Michelson.Parameterisation as Param
 import qualified Juvix.Core as Core
-import qualified Juvix.Core.Erased as Erased
 import qualified Juvix.Core.Erasure as Erasure
 import qualified Juvix.Core.HR as HR
 import Juvix.Library

--- a/doc/Code/App.org
+++ b/doc/Code/App.org
@@ -3,7 +3,6 @@
   + [[Compilation]]
   + [[Parameterisation]]
   + [[Core]]
-  + [[Erased]]
   + [[Erasure]]
   + [[HR]]
   + [[Library]]

--- a/doc/Code/Juvix.org
+++ b/doc/Code/Juvix.org
@@ -359,7 +359,6 @@ This module provides a default contract environment
 - Types used internally by the Michelson backend.
 - _Relies on_
   + [[ErasedAnn/Types]]
-  + [[Core/Types]]
   + [[Library]]
 ***** VirtualStack
 - Serves as a virtual stack over Michelson
@@ -552,9 +551,7 @@ This module provides a default contract environment
 **** Extend <<Erased/Extend>>
 - _Relies on_
   + [[HRAnn/Extend]]
-  + [[IR/Types]]
   + [[IR/Types/Base]]
-  + [[Library]]
 **** Util
 - _Relies on_
   + [[Erased/Types]]
@@ -563,12 +560,9 @@ This module provides a default contract environment
 - _Relies on_
   + [[Erased/Extend]]
   + [[Erased/Types/Base]]
-  + [[HRAnn/Types]]
   + [[IR/Types/Base]]
   + [[IR/Types/Base]]
-  + [[Usage]]
   + [[Library]]
-  + [[HashMap]]
 ***** Base <<Erased/Types/Base>>
 - _Relies on_
   + [[IR/Types]]
@@ -638,7 +632,6 @@ This module provides a default contract environment
 **** Extend <<HR/Extend>>
 - _Relies on_
   + [[IR/Types/Base]]
-  + [[IR/Types/Base]]
   + [[Library]]
 **** Parser <<HR/Parser>>
 - _Relies on_
@@ -651,7 +644,6 @@ This module provides a default contract environment
   + [[HR/Extend]]
   + [[IR/Types/Base]]
   + [[IR/Types/Base]]
-  + [[Library]]
 *** HRAnn
 - _Relies on_
   + [[HRAnn/Erasure]]
@@ -665,7 +657,6 @@ This module provides a default contract environment
 **** Extend <<HRAnn/Extend>>
 - _Relies on_
   + [[IR/Types/Base]]
-  + [[IR/Types/Base]]
   + [[Usage]]
   + [[Library]]
 **** Types <<HRAnn/Types>>
@@ -673,8 +664,6 @@ This module provides a default contract environment
   + [[HRAnn/Extend]]
   + [[IR/Types/Base]]
   + [[IR/Types/Base]]
-  + [[Usage]]
-  + [[Library]]
 *** IR
 - _Relies on_
   + [[IR/Evaluator]]

--- a/doc/Code/Test.org
+++ b/doc/Code/Test.org
@@ -144,7 +144,6 @@ Tests for the type checker and evaluator in Core/IR/Typechecker.hs
 - _Relies on_
   + [[Context]]
   + [[Library]]
-* Files
 * FrontendContextualise
 ** Infix
 *** ShuntYard

--- a/src/Juvix/Backends/Michelson/Compilation/Types.hs
+++ b/src/Juvix/Backends/Michelson/Compilation/Types.hs
@@ -7,7 +7,6 @@ module Juvix.Backends.Michelson.Compilation.Types
 where
 
 import qualified Juvix.Core.ErasedAnn.Types as CoreErased
-import qualified Juvix.Core.Types as CoreErr
 import Juvix.Library
 import qualified Michelson.TypeCheck as M
 import qualified Michelson.Typed as MT

--- a/src/Juvix/Backends/Michelson/DSL/InstructionsEff.hs
+++ b/src/Juvix/Backends/Michelson/DSL/InstructionsEff.hs
@@ -848,5 +848,5 @@ applyLambdaFromStorage sym ty arg = do
   pure [lam, arg, Instructions.exec]
 
 applyLambdaFromStorageNArgs :: Env.Reduction m => Symbol -> MT.Type -> [Types.NewTerm] -> m Env.Expanded
-applyLambdaFromStorageNArgs sym ty args = Env.Expanded . mconcat |<< do
+applyLambdaFromStorageNArgs _sym _ty _args = Env.Expanded . mconcat |<< do
   undefined

--- a/src/Juvix/Core/EAC/ConstraintGen.hs
+++ b/src/Juvix/Core/EAC/ConstraintGen.hs
@@ -204,7 +204,7 @@ boxAndTypeConstraint parameterisation parameterizedAssignment term = do
         (EAC.Constraint [EAC.ConstraintVar 1 (bangParam resTy)] (EAC.Gte 0))
       -- Return parameterized term.
       pure (EAC.RBang param (EAC.RLam sym body), resTy)
-    Erased.Let s t b -> do
+    Erased.Let _s _t _b -> do
       error "TODO"
     Erased.App a b -> do
       (a, aTy) <- rec a

--- a/src/Juvix/Core/Erased/Extend.hs
+++ b/src/Juvix/Core/Erased/Extend.hs
@@ -1,38 +1,35 @@
 module Juvix.Core.Erased.Extend where
 
+import Extensible (TypeQ)
 import qualified Juvix.Core.HRAnn.Extend as HR
 import Juvix.Core.IR.Types.Base
 
--- extTerm :: template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
---                  -> template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
---                  -> ExtTerm
+extTerm :: TypeQ -> TypeQ -> ExtTerm
 extTerm = HR.extTerm
 
--- extTerm :: template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
---                  -> template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
--- -> ExtElim
+extElim :: TypeQ -> TypeQ -> ExtElim
 extElim = HR.extElim
 
 extValue :: p1 -> p2 -> ExtValue
-extValue = \_ _ -> defaultExtValue
+extValue _ _ = defaultExtValue
 
 extNeutral :: p1 -> p2 -> ExtNeutral
-extNeutral = \_ _ -> defaultExtNeutral
+extNeutral _ _ = defaultExtNeutral
 
 extDatatype :: p1 -> p2 -> ExtDatatype
-extDatatype = \_ _ -> defaultExtDatatype
+extDatatype _ _ = defaultExtDatatype
 
 extDataArg :: p1 -> p2 -> ExtDataArg
-extDataArg = \_ _ -> defaultExtDataArg
+extDataArg _ _ = defaultExtDataArg
 
 extDataCon :: p1 -> p2 -> ExtDataCon
-extDataCon = \_ _ -> defaultExtDataCon
+extDataCon _ _ = defaultExtDataCon
 
 extFunction :: p1 -> p2 -> ExtFunction
-extFunction = \_ _ -> defaultExtFunction
+extFunction _ _ = defaultExtFunction
 
 extFunClause :: p1 -> p2 -> ExtFunClause
-extFunClause = \_ _ -> defaultExtFunClause
+extFunClause _ _ = defaultExtFunClause
 
 extPattern :: p1 -> p2 -> ExtPattern
-extPattern = \_ _ -> defaultExtPattern
+extPattern _ _ = defaultExtPattern

--- a/src/Juvix/Core/Erased/Extend.hs
+++ b/src/Juvix/Core/Erased/Extend.hs
@@ -1,26 +1,38 @@
 module Juvix.Core.Erased.Extend where
 
 import qualified Juvix.Core.HRAnn.Extend as HR
-import qualified Juvix.Core.IR.Types as IR
 import Juvix.Core.IR.Types.Base
-import Juvix.Library
 
+-- extTerm :: template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
+--                  -> template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
+--                  -> ExtTerm
 extTerm = HR.extTerm
 
+-- extTerm :: template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
+--                  -> template-haskell-2.15.0.0:Language.Haskell.TH.Lib.Internal.TypeQ
+-- -> ExtElim
 extElim = HR.extElim
 
+extValue :: p1 -> p2 -> ExtValue
 extValue = \_ _ -> defaultExtValue
 
+extNeutral :: p1 -> p2 -> ExtNeutral
 extNeutral = \_ _ -> defaultExtNeutral
 
+extDatatype :: p1 -> p2 -> ExtDatatype
 extDatatype = \_ _ -> defaultExtDatatype
 
+extDataArg :: p1 -> p2 -> ExtDataArg
 extDataArg = \_ _ -> defaultExtDataArg
 
+extDataCon :: p1 -> p2 -> ExtDataCon
 extDataCon = \_ _ -> defaultExtDataCon
 
+extFunction :: p1 -> p2 -> ExtFunction
 extFunction = \_ _ -> defaultExtFunction
 
+extFunClause :: p1 -> p2 -> ExtFunClause
 extFunClause = \_ _ -> defaultExtFunClause
 
+extPattern :: p1 -> p2 -> ExtPattern
 extPattern = \_ _ -> defaultExtPattern

--- a/src/Juvix/Core/Erased/Types.hs
+++ b/src/Juvix/Core/Erased/Types.hs
@@ -8,7 +8,6 @@ where
 
 import Juvix.Core.Erased.Extend
 import Juvix.Core.Erased.Types.Base
-import Juvix.Core.HRAnn.Types (Annotation (..), AppAnnotation (..), BindAnnotation (..))
 import qualified Juvix.Core.IR.Types.Base as IR
 import Juvix.Core.IR.Types.Base hiding
   ( Term' (..),
@@ -16,15 +15,10 @@ import Juvix.Core.IR.Types.Base hiding
     extDataArg,
     extDataCon,
     extDatatype,
-    extFunClause,
     extFunction,
-    extPattern,
-    extTerm,
     extendTerm,
   )
-import qualified Juvix.Core.Usage as Usage
 import Juvix.Library hiding (Type)
-import qualified Juvix.Library.HashMap as Map
 
 data T
 

--- a/src/Juvix/Core/HR/Extend.hs
+++ b/src/Juvix/Core/HR/Extend.hs
@@ -1,9 +1,9 @@
 module Juvix.Core.HR.Extend where
 
-import qualified Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
 import Juvix.Library
 
+extTerm :: p1 -> p2 -> IR.ExtTerm
 extTerm =
   \_primTy _primVal ->
     IR.defaultExtTerm
@@ -15,6 +15,7 @@ extTerm =
         IR.typeLet = Just [[t|Symbol|]]
       }
 
+extElim :: p1 -> p2 -> IR.ExtElim
 extElim =
   \_primTy _primVal ->
     IR.defaultExtElim

--- a/src/Juvix/Core/HR/Types.hs
+++ b/src/Juvix/Core/HR/Types.hs
@@ -3,7 +3,6 @@ module Juvix.Core.HR.Types where
 import Juvix.Core.HR.Extend
 import Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
-import Juvix.Library
 
 data T
 

--- a/src/Juvix/Core/HRAnn/Extend.hs
+++ b/src/Juvix/Core/HRAnn/Extend.hs
@@ -1,7 +1,6 @@
 module Juvix.Core.HRAnn.Extend where
 
 import qualified Extensible as Ext
-import qualified Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
 import qualified Juvix.Core.Usage as Usage
 import Juvix.Library
@@ -27,6 +26,7 @@ data LetAnnotation primTy primVal
       }
 
 -- TODO: add combinators to @extensible-data@ for pairing like this
+extTerm :: Ext.TypeQ -> Ext.TypeQ -> IR.ExtTerm
 extTerm =
   \primTy primVal ->
     IR.defaultExtTerm
@@ -46,6 +46,7 @@ data AppAnnotation primTy primVal
         argAnn :: {-# UNPACK #-} !(Annotation primTy primVal)
       }
 
+extElim :: Ext.TypeQ -> Ext.TypeQ -> IR.ExtElim
 extElim =
   \primTy primVal ->
     IR.defaultExtElim

--- a/src/Juvix/Core/HRAnn/Types.hs
+++ b/src/Juvix/Core/HRAnn/Types.hs
@@ -4,12 +4,9 @@ module Juvix.Core.HRAnn.Types
   )
 where
 
-import qualified Extensible as Ext
 import Juvix.Core.HRAnn.Extend
 import qualified Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
-import qualified Juvix.Core.Usage as Usage
-import Juvix.Library
 
 -- TODO: add combinators to @extensible-data@ for pairing like this
 IR.extendTerm "Term" [] [t|T|] extTerm

--- a/src/Juvix/Core/IRAnn/Types.hs
+++ b/src/Juvix/Core/IRAnn/Types.hs
@@ -1,6 +1,5 @@
 module Juvix.Core.IRAnn.Types where
 
-import qualified Extensible as Ext
 import qualified Juvix.Core.IR.Types.Base
 import qualified Juvix.Core.IR.Types.Base as IR
 import qualified Juvix.Core.Usage as Usage

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,5 @@
 module Main where
 
-import qualified Backends.ArithmeticCircuit as ArithmeticCircuit
 import qualified Backends.LLVM as LLVM
 import qualified Backends.Michelson as Michelson
 import qualified CoreConv
@@ -14,7 +13,6 @@ import qualified FrontendDesugar
 import Juvix.Library hiding (identity)
 import qualified Pipeline
 import qualified Test.Tasty as T
-import qualified Test.Tasty.QuickCheck as T
 
 coreTests :: T.TestTree
 coreTests =


### PR DESCRIPTION
Clean up warnings. More `undefined` and `incomplete pattern match` to be cleaned up.

The hope is that cleaning up the `undefined` and `incomplete pattern match` would decrease errors and mistakes etc.