### PR TITLE
Adds IDE info to the build package

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -114,6 +114,7 @@ ghc-options:
   - -fno-warn-missing-pattern-synonym-signatures
   - -j
   - -static
+  - -fwrite-ide-info
 
 when:
   condition: flag(incomplete-error)


### PR DESCRIPTION
this will only effect the `./stack-build` directory and not cloud the programming directory with .hie files, unless one is running emacs.


Emacs seems to leverage the local ones(?) quite well, and I notice a significant CPU load decrease when these files are up to date.

Just good to have this flag


Is there any other places this needs to be added, or does the options here effect all (executable, test, benchmarks) options?