### PR TITLE
Add fields to parameterisations for injecting constants

### DIFF
--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
@@ -17,6 +17,7 @@ import Juvix.Core.Types hiding
     reservedOpNames,
     typeOf,
   )
+import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -126,4 +127,12 @@ reservedOpNames =
 
 t :: Parameterisation Ty Val
 t =
-  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \i _ -> False, -- TODO
+    intVal = const Nothing, -- TODO
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
@@ -11,6 +11,7 @@ import Juvix.Core.Types hiding
     reservedOpNames,
     typeOf,
   )
+import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -86,4 +87,13 @@ reservedOpNames :: [String]
 reservedOpNames = []
 
 t :: FieldT e b => Parameterisation Ty (Val (e f b) b)
-t = Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+t =
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
@@ -10,6 +10,7 @@ import Juvix.Core.Types hiding
     reservedOpNames,
     typeOf,
   )
+import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -70,4 +71,12 @@ reservedOpNames = []
 
 t :: FieldElement e => Parameterisation Ty (Val (e f f))
 t =
-  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
@@ -11,6 +11,7 @@ import Juvix.Core.Types hiding
     reservedOpNames,
     typeOf,
   )
+import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -86,4 +87,12 @@ reservedOpNames = []
 
 t :: FieldT e i => Parameterisation Ty (Val (e f i) i)
 t =
-  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \i _ -> False, -- TODO
+    intVal = const Nothing, -- TODO
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -164,8 +164,8 @@ michelson =
     stringVal = Just . Constant . M.ValueString . M.mkMTextUnsafe, -- TODO ?
     intTy = checkIntType,
     intVal = integerToPrimVal,
-    floatTy = \_ _ -> False, -- TODO
-    floatVal = const Nothing -- TODO
+    floatTy = \_ _ -> False, -- Michelson does not support floats
+    floatVal = const Nothing
   }
 
 type CompErr = CompTypes.CompilationError

--- a/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -22,6 +22,7 @@ import Juvix.Library hiding (many, try)
 import qualified Michelson.Macro as M
 import qualified Michelson.Parser as M
 import qualified Michelson.Untyped as M
+import qualified Michelson.Text as M
 import qualified Michelson.Untyped.Type as Untyped
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -135,15 +136,36 @@ reservedNames = []
 reservedOpNames :: [String]
 reservedOpNames = []
 
+integerToPrimVal :: Integer -> Maybe PrimVal
+integerToPrimVal x
+  | x >= toInteger (minBound @Int),
+    x <= toInteger (maxBound @Int)
+  = Just $ Constant $ M.ValueInt $ fromInteger x
+  | otherwise
+  = Nothing
+
+checkStringType :: Text -> PrimTy -> Bool
+checkStringType val (PrimTy (M.Type ty _)) = case ty of
+  M.TString -> Text.all M.isMChar val
+  _         -> False
+
+checkIntType :: Integer -> PrimTy -> Bool
+checkIntType val (PrimTy (M.Type ty _)) = case ty of
+  M.TNat -> val >= 0 -- TODO max bound
+  M.TInt -> True -- TODO bounds?
+  _      -> False
+
 -- TODO: Figure out what the parser ought to do.
 michelson :: Core.Parameterisation PrimTy PrimVal
 michelson =
-  Core.Parameterisation
-    typeOf
-    apply
-    parseTy
-    parseVal
-    reservedNames
-    reservedOpNames
+  Core.Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = checkStringType,
+    stringVal = Just . Constant . M.ValueString . M.mkMTextUnsafe, -- TODO ?
+    intTy = checkIntType,
+    intVal = integerToPrimVal,
+    floatTy = \_ _ -> False, -- TODO
+    floatVal = const Nothing -- TODO
+  }
 
 type CompErr = CompTypes.CompilationError

--- a/src/Juvix/Core/Parameterisation.hs
+++ b/src/Juvix/Core/Parameterisation.hs
@@ -13,7 +13,16 @@ data Parameterisation primTy primVal
         parseTy :: Token.GenTokenParser String () Identity -> Parser primTy,
         parseVal :: Token.GenTokenParser String () Identity -> Parser primVal,
         reservedNames :: [String],
-        reservedOpNames :: [String]
+        reservedOpNames :: [String],
+
+        stringTy :: Text -> primTy -> Bool,
+        stringVal :: Text -> Maybe primVal,
+
+        intTy :: Integer -> primTy -> Bool,
+        intVal :: Integer -> Maybe primVal,
+
+        floatTy :: Double -> primTy -> Bool,
+        floatVal :: Double -> Maybe primVal
       }
   deriving (Generic)
 

--- a/src/Juvix/Core/Parameterisations/All.hs
+++ b/src/Juvix/Core/Parameterisations/All.hs
@@ -10,6 +10,7 @@ import Juvix.Core.Types hiding
     reservedOpNames,
     typeOf,
   )
+import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -66,4 +67,12 @@ reservedOpNames = Naturals.reservedOpNames <> Unit.reservedOpNames
 
 t :: Parameterisation Ty Val
 t =
-  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \i _ -> Naturals.isNat i,
+    intVal = fmap NatVal . Naturals.natVal,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -8,11 +8,12 @@ import Juvix.Core.Types hiding
     reservedOpNames,
     typeOf,
   )
-import Juvix.Library hiding ((<|>))
+import Juvix.Library hiding ((<|>), natVal)
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
 import Text.Show
 import Prelude (String)
+import qualified Juvix.Core.Parameterisation as P
 
 -- k: primitive type: naturals
 data Ty
@@ -78,6 +79,20 @@ reservedNames = ["Nat", "+", "-", "*"]
 reservedOpNames :: [String]
 reservedOpNames = []
 
+isNat :: Integer -> Bool
+isNat i = i >= 0
+
+natVal :: Integer -> Maybe Val
+natVal i = if i >= 0 then Just (Val (fromIntegral i)) else Nothing
+
 t :: Parameterisation Ty Val
 t =
-  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \i _ -> isNat i,
+    intVal = natVal,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -12,6 +12,7 @@ import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
 import Prelude (String)
+import qualified Juvix.Core.Parameterisation as P
 
 -- k: primitive type: unit
 data Ty
@@ -47,4 +48,12 @@ reservedOpNames = []
 
 t :: Parameterisation Ty Val
 t =
-  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+  Parameterisation {
+    typeOf, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/test/EAC2.hs
+++ b/test/EAC2.hs
@@ -19,7 +19,20 @@ type TypeAssignment = ET.TypeAssignment ()
 
 unitParam :: Types.Parameterisation () ()
 unitParam =
-  Types.Parameterisation (const (() :| [])) (\_ _ -> Nothing) undefined undefined [] []
+  Types.Parameterisation {
+    typeOf = const $ () :| [],
+    apply = \_ _ -> Nothing,
+    parseTy = const empty,
+    parseVal = const empty,
+    reservedNames = [],
+    reservedOpNames = [],
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }
 
 shouldGen ::
   T.TestName ->


### PR DESCRIPTION
Basically what is added is a field `intTy :: Integer -> primTy -> Bool` to check whether a literal is valid for a given type (in range, etc), and `intVal :: Integer -> Maybe primVal` to wrap an integer (if possible), and similarly for `Text` and `Double` (which maybe we should switch to `Rational`? either way)

There are some parts which are still missing currently:
  - `intTy` and `intVal` currently reject everything in `Backends.ArithmeticCircuit.Parameterisation[.Integers]`, because I didn't know what the valid range was, or if we want `0` and `1` to type as bool as well. Strings and floats are also rejected but I don't think they exist in ACs.
  - The additions in `Michelson.Parameterisation` should definitely be looked over by someone which knows more about what is valid in michelson values