### PR TITLE
Make typechecker (& evaluator) polymorphic over the monad and extension

### DIFF
--- a/src/Juvix/Core/Erased/Extend.hs
+++ b/src/Juvix/Core/Erased/Extend.hs
@@ -16,20 +16,5 @@ extValue _ _ = defaultExtValue
 extNeutral :: p1 -> p2 -> ExtNeutral
 extNeutral _ _ = defaultExtNeutral
 
-extDatatype :: p1 -> p2 -> ExtDatatype
-extDatatype _ _ = defaultExtDatatype
-
-extDataArg :: p1 -> p2 -> ExtDataArg
-extDataArg _ _ = defaultExtDataArg
-
-extDataCon :: p1 -> p2 -> ExtDataCon
-extDataCon _ _ = defaultExtDataCon
-
-extFunction :: p1 -> p2 -> ExtFunction
-extFunction _ _ = defaultExtFunction
-
-extFunClause :: p1 -> p2 -> ExtFunClause
-extFunClause _ _ = defaultExtFunClause
-
 extPattern :: p1 -> p2 -> ExtPattern
 extPattern _ _ = defaultExtPattern

--- a/src/Juvix/Core/Erased/Types.hs
+++ b/src/Juvix/Core/Erased/Types.hs
@@ -12,10 +12,6 @@ import qualified Juvix.Core.IR.Types.Base as IR
 import Juvix.Core.IR.Types.Base hiding
   ( Term' (..),
     defaultExtTerm,
-    extDataArg,
-    extDataCon,
-    extDatatype,
-    extFunction,
     extendTerm,
   )
 import Juvix.Core.Usage (Usage)
@@ -27,6 +23,12 @@ extendTerm "Term" [] [t|T|] (\_ -> defaultExtTerm)
 
 extendType "Type" [] [t|T|] (\_ -> defaultExtType)
 
+
+type Datatype = Datatype' T
+type DataArg = DataArg' T
+type DataCon = DataCon' T
+type Function = Function' T
+type FunClause = FunClause' T
 type TypeAssignment primTy = TypeAssignment' T primTy
 
 data EvaluationError primVal

--- a/src/Juvix/Core/IR.hs
+++ b/src/Juvix/Core/IR.hs
@@ -13,8 +13,6 @@ import Juvix.Core.IR.Typechecker as IR
     Context,
     EnvCtx,
     EnvTypecheck (..),
-    Global (..),
-    Globals,
     Leftovers (..),
     TypecheckError,
     TypecheckError' (..),

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -199,16 +199,20 @@ requireUniverseLT :: HasThrowTC' IR.NoExt ext primTy primVal m
 requireUniverseLT i j = unless (i < j) $ throwTC (UniverseMismatch i j)
 
 requirePrimType ::
+  CanInnerTC' ext primTy primVal m =>
   primVal ->
   IR.Value primTy primVal ->
-  InnerTC primTy primVal ()
+  m ()
 requirePrimType p ty = do
   param <- ask @"param"
   ty' <- toPrimTy ty
   unless (Param.hasType param p ty') $
     throwTC (WrongPrimTy p ty')
 
-toPrimTy :: IR.Value primTy primVal -> InnerTC primTy primVal (NonEmpty primTy)
+toPrimTy ::
+  CanInnerTC' ext primTy primVal m =>
+  IR.Value primTy primVal ->
+  m (NonEmpty primTy)
 toPrimTy ty = maybe (throwTC $ NotPrimTy ty) pure $ go ty
   where
     go (IR.VPrimTy t) = pure $ t :| []

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -11,19 +11,20 @@ import qualified Juvix.Core.IR.Evaluator as Eval
 import Juvix.Core.IR.Typechecker.Env as Env
 import Juvix.Core.IR.Typechecker.Types as Typed
 import qualified Juvix.Core.IR.Types as IR
+import qualified Juvix.Core.IR.Types.Base as IR
 import qualified Juvix.Core.Parameterisation as Param
 import qualified Juvix.Core.Usage as Usage
 import Juvix.Library hiding (Datatype)
 
-data Leftovers primTy primVal a
+data Leftovers a
   = Leftovers
       { loValue :: a,
-        loLocals :: UContext primTy primVal,
-        loPatVars :: PatUsages primTy primVal
+        loLocals :: UContext,
+        loPatVars :: PatUsages
       }
   deriving (Eq, Show, Generic)
 
-leftoversOk :: Leftovers primTy primVal a -> Bool
+leftoversOk :: Leftovers a -> Bool
 leftoversOk (Leftovers {loLocals, loPatVars}) =
   all leftoverOk loLocals && all leftoverOk loPatVars
 
@@ -41,128 +42,133 @@ typeTerm ::
 typeTerm param t ann = loValue <$> typeTermWith param IntMap.empty [] t ann
 
 typeTermWith ::
-  (Eq primTy, Eq primVal) =>
+  (Eq primTy, Eq primVal, CanTC primTy primVal m) =>
   Param.Parameterisation primTy primVal ->
   PatBinds primTy primVal ->
   Context primTy primVal ->
   IR.Term primTy primVal ->
   Annotation primTy primVal ->
-  EnvTypecheck primTy primVal
-    (Leftovers primTy primVal (Typed.Term primTy primVal))
+  m (Leftovers (Typed.Term primTy primVal))
 typeTermWith param pats ctx t ann =
   execInner (withLeftovers $ typeTerm' t ann) (InnerState param pats ctx)
 
 -- | Infers the type and usage for an 'Elim' and returns it decorated with this
 -- information.
 typeElim ::
-  (Eq primTy, Eq primVal) =>
+  (Eq primTy, Eq primVal, CanTC primTy primVal m) =>
   Param.Parameterisation primTy primVal ->
   IR.Elim primTy primVal ->
   Usage.T ->
-  EnvTypecheck primTy primVal (Typed.Elim primTy primVal)
+  m (Typed.Elim primTy primVal)
 typeElim param e σ =
   loValue <$> typeElimWith param IntMap.empty [] e σ
 
 typeElimWith ::
-  (Eq primTy, Eq primVal) =>
+  (Eq primTy, Eq primVal, CanTC primTy primVal m) =>
   Param.Parameterisation primTy primVal ->
   PatBinds primTy primVal ->
   Context primTy primVal ->
   IR.Elim primTy primVal ->
   Usage.T ->
-  EnvTypecheck primTy primVal
-    (Leftovers primTy primVal (Typed.Elim primTy primVal))
+  m (Leftovers (Typed.Elim primTy primVal))
 typeElimWith param pats ctx e σ =
   execInner (withLeftovers $ typeElim' e σ) (InnerState param pats ctx)
 
 withLeftovers ::
-  InnerTC primTy primVal a ->
-  InnerTC primTy primVal (Leftovers primTy primVal a)
+  (HasBound primTy primVal m, HasPatBinds primTy primVal m) =>
+  m a -> m (Leftovers a)
 withLeftovers m =
   Leftovers <$> m
     <*> fmap (fmap annUsage) (get @"bound")
     <*> fmap (fmap annUsage) (get @"patBinds")
 
 typeTerm' ::
-  (Eq primTy, Eq primVal, CanInnerTC primTy primVal m) =>
-  IR.Term primTy primVal ->
+  (Eq primTy, Eq primVal, CanInnerTC' ext primTy primVal m) =>
+  IR.Term' ext primTy primVal ->
   Annotation primTy primVal ->
   m (Typed.Term primTy primVal)
 typeTerm' term ann@(Annotation σ ty) =
   case term of
-    IR.Star i -> do
+    IR.Star' i _ -> do
       requireZero σ
       j <- requireStar ty
       requireUniverseLT i j
       pure $ Typed.Star i ann
-    IR.PrimTy t -> do
+    IR.PrimTy' t _ -> do
       requireZero σ
       void $ requireStar ty
       pure $ Typed.PrimTy t ann
-    IR.Prim p -> do
+    IR.Prim' p _ -> do
       requirePrimType p ty
       pure $ Typed.Prim p $ Annotation σ ty
-    IR.Pi π a b -> do
+    IR.Pi' π a b _ -> do
       requireZero σ
       void $ requireStar ty
       a' <- typeTerm' a ann
       b' <- typeTerm' b ann
       pure $ Typed.Pi π a' b' ann
-    IR.Lam t -> do
+    IR.Lam' t _ -> do
       (π, a, b) <- requirePi ty
       let varAnn = Annotation (σ <.> π) a
           tAnn = Annotation σ b
       t' <- withLocal varAnn $ typeTerm' t tAnn
       let anns = BindAnnotation {baBindAnn = varAnn, baResAnn = ann}
       pure $ Typed.Lam t' anns
-    IR.Let σb b t -> do
+    IR.Let' σb b t _ -> do
       b' <- typeElim' b σb
       let bAnn = getElimAnn b'
           tAnn = Annotation σ (Eval.weak ty)
       t' <- withLocal bAnn $ typeTerm' t tAnn
       let anns = BindAnnotation {baBindAnn = bAnn, baResAnn = ann}
       pure $ Typed.Let σb b' t' anns
-    IR.Elim e -> do
+    IR.Elim' e _ -> do
       e' <- typeElim' e σ
       let ty' = annType $ getElimAnn e'
       requireSubtype e ty ty'
       pure $ Typed.Elim e' ann
+    IR.TermX x ->
+      throwTC $ UnsupportedTermExt x
 
 typeElim' ::
-  (Eq primTy, Eq primVal, CanInnerTC primTy primVal m) =>
-  IR.Elim primTy primVal ->
+  (Eq primTy, Eq primVal, CanInnerTC' ext primTy primVal m) =>
+  IR.Elim' ext primTy primVal ->
   Usage.T ->
   m (Typed.Elim primTy primVal)
 typeElim' elim σ =
   case elim of
-    IR.Bound i -> do
+    IR.Bound' i _ -> do
       ty <- useLocal σ i
       pure $ Typed.Bound i $ Annotation σ ty
-    IR.Free px@(IR.Pattern x) -> do
+    IR.Free' px@(IR.Pattern x) _ -> do
       ty <- usePatVar σ x
       pure $ Typed.Free px $ Annotation σ ty
-    IR.Free gx@(IR.Global x) -> do
+    IR.Free' gx@(IR.Global x) _ -> do
       (ty, π') <- lookupGlobal x
       when (π' == IR.GZero) $ requireZero σ
       pure $ Typed.Free gx $ Annotation σ ty
-    IR.App s t -> do
+    IR.App' s t _ -> do
       s' <- typeElim' s σ
       (π, a, b) <- requirePi $ annType $ getElimAnn s'
       let tAnn = Annotation (σ <.> π) a
       t' <- typeTerm' t tAnn
       ty <- substApp b t
       pure $ Typed.App s' t' $ Annotation σ ty
-    IR.Ann π s a ℓ -> do
+    IR.Ann' π s a ℓ _ -> do
       a' <- typeTerm' a $ Annotation mempty (IR.VStar ℓ)
       ty <- evalTC a
       let ann = Annotation σ ty
       s' <- typeTerm' s ann
       pure $ Typed.Ann π s' a' ℓ ann
+    IR.ElimX x ->
+      throwTC $ UnsupportedElimExt x
 
-pushLocal :: HasBound primTy primVal m => Annotation primTy primVal -> m ()
+pushLocal :: HasBound primTy primVal m
+          => Annotation primTy primVal -> m ()
 pushLocal ann = modify @"bound" (ann :)
 
-popLocal :: (HasBound primTy primVal m, HasThrowTC primTy primVal m) => m ()
+popLocal :: (HasBound primTy primVal m,
+             HasThrowTC' IR.NoExt ext primTy primVal m)
+         => m ()
 popLocal = do
   ctx <- get @"bound"
   case ctx of
@@ -173,21 +179,22 @@ popLocal = do
       throwTC (UnboundIndex 0)
 
 withLocal ::
-  (HasBound primTy primVal m, HasThrowTC primTy primVal m) =>
+  (HasBound primTy primVal m,
+   HasThrowTC' IR.NoExt ext primTy primVal m) =>
   Annotation primTy primVal ->
   m a -> m a
 withLocal ann m = pushLocal ann *> m <* popLocal
 
-requireZero :: HasThrowTC primTy primVal m
+requireZero :: HasThrowTC' IR.NoExt ext primTy primVal m
             => Usage.T -> m ()
 requireZero π = unless (π == mempty) $ throwTC (UsageMustBeZero π)
 
-requireStar :: HasThrowTC primTy primVal m
+requireStar :: HasThrowTC' IR.NoExt ext primTy primVal m
             => IR.Value primTy primVal -> m IR.Universe
 requireStar (IR.VStar j) = pure j
 requireStar ty = throwTC (ShouldBeStar ty)
 
-requireUniverseLT :: HasThrowTC primTy primVal m
+requireUniverseLT :: HasThrowTC' IR.NoExt ext primTy primVal m
                   => IR.Universe -> IR.Universe -> m ()
 requireUniverseLT i j = unless (i < j) $ throwTC (UniverseMismatch i j)
 
@@ -212,15 +219,15 @@ type PiParts primTy primVal =
   (Usage.T, IR.Value primTy primVal, IR.Value primTy primVal)
 
 requirePi ::
-  HasThrowTC primTy primVal m =>
+  HasThrowTC' IR.NoExt ext primTy primVal m =>
   IR.Value primTy primVal ->
   m (PiParts primTy primVal)
 requirePi (IR.VPi π a b) = pure (π, a, b)
 requirePi ty = throwTC (ShouldBeFunctionType ty)
 
 requireSubtype ::
-  (Eq primTy, Eq primVal, HasThrowTC primTy primVal m) =>
-  IR.Elim primTy primVal ->
+  (Eq primTy, Eq primVal, HasThrowTC' IR.NoExt ext primTy primVal m) =>
+  IR.Elim' ext primTy primVal ->
   IR.Value primTy primVal ->
   IR.Value primTy primVal ->
   m ()
@@ -228,7 +235,8 @@ requireSubtype subj exp got =
   unless (got <: exp) $ throwTC (TypeMismatch subj exp got)
 
 useLocal ::
-  (HasBound primTy primVal m, HasThrowTC primTy primVal m) =>
+  (HasBound primTy primVal m,
+   HasThrowTC' IR.NoExt ext primTy primVal m) =>
   Usage.T ->
   IR.BoundVar ->
   m (IR.Value primTy primVal)
@@ -246,7 +254,8 @@ useLocal π var = do
     go w i (b : ctx) = second (b :) <$> go (w + 1) (i - 1) ctx
 
 usePatVar ::
-  (HasPatBinds primTy primVal m, HasThrowTC primTy primVal m) =>
+  (HasPatBinds primTy primVal m,
+   HasThrowTC' IR.NoExt ext primTy primVal m) =>
   Usage.T ->
   IR.PatternVar ->
   m (IR.Value primTy primVal)
@@ -264,9 +273,10 @@ usePatVar π var = do
       throwTC (UnboundPatVar var)
 
 substApp ::
-  (HasParam primTy primVal m, HasThrowTC primTy primVal m) =>
+  (HasParam primTy primVal m,
+   HasThrowTC' IR.NoExt ext primTy primVal m) =>
   IR.Value primTy primVal ->
-  IR.Term primTy primVal ->
+  IR.Term' ext primTy primVal ->
   m (IR.Value primTy primVal)
 substApp ty arg = do
   arg' <- evalTC arg
@@ -274,8 +284,9 @@ substApp ty arg = do
   Eval.substV param arg' ty
 
 evalTC ::
-  (HasParam primTy primVal m, HasThrowTC primTy primVal m) =>
-  IR.Term primTy primVal ->
+  (HasParam primTy primVal m,
+   HasThrowTC' IR.NoExt ext primTy primVal m) =>
+  IR.Term' ext primTy primVal ->
   m (IR.Value primTy primVal)
 evalTC t = do
   param <- ask @"param"
@@ -294,12 +305,15 @@ evalTC t = do
 -- * It doesn't descend into any other structures
 --   (TODO: which ones are safe to do so?)
 (<:) ::
-  (Eq primTy, Eq primVal) =>
-  IR.Value primTy primVal ->
-  IR.Value primTy primVal ->
+  ( Eq primTy, Eq primVal,
+    IR.ValueAll Eq ext primTy primVal,
+    IR.NeutralAll Eq ext primTy primVal
+  ) =>
+  IR.Value' ext primTy primVal ->
+  IR.Value' ext primTy primVal ->
   Bool
-IR.VStar i <: IR.VStar j = i <= j
-IR.VPi π1 s1 t1 <: IR.VPi π2 s2 t2 =
+IR.VStar' i _ <: IR.VStar' j _ = i <= j
+IR.VPi' π1 s1 t1 _ <: IR.VPi' π2 s2 t2 _ =
   π2 `Usage.allows` π1 && s2 <: s1 && t1 <: t2
 s1 <: s2 = s1 == s2
 

--- a/src/Juvix/Core/IR/Typechecker/Env.hs
+++ b/src/Juvix/Core/IR/Typechecker/Env.hs
@@ -1,50 +1,68 @@
 module Juvix.Core.IR.Typechecker.Env where
 
+import Data.Foldable (foldr1) -- (on a NonEmpty)
 import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
 import qualified Juvix.Core.IR.Evaluator as Eval
 import Juvix.Core.IR.Typechecker.Types
 import qualified Juvix.Core.IR.Types as IR
+import qualified Juvix.Core.IR.Types.Base as IR
 import qualified Juvix.Core.Parameterisation as Param
 import qualified Juvix.Core.Usage as Usage
 import Juvix.Library hiding (Datatype)
 
-data EnvCtx primTy primVal
+data EnvCtx' ext primTy primVal
   = EnvCtx
-      { globals :: Globals primTy primVal
+      { globals :: Globals' ext primTy primVal
       }
-  deriving (Show, Eq, Generic)
+  deriving Generic
 
-type Globals primTy primVal =
-  HashMap IR.GlobalName (Global primTy primVal)
+type EnvCtx = EnvCtx' IR.NoExt
 
-data Global primTy primVal
-  = GDatatype (IR.Datatype primTy primVal)
-  | GDataCon (IR.DataCon primTy primVal)
-  | GFunction (IR.Function primTy primVal)
-  | GAbstract IR.GlobalUsage (IR.Value primTy primVal)
-  deriving (Show, Eq, Generic)
+type Globals' ext primTy primVal =
+  HashMap IR.GlobalName (Global' ext primTy primVal)
 
-type EnvAlias primTy primVal =
+type Globals primTy primVal = Globals' IR.NoExt primTy primVal
+
+data Global' ext primTy primVal
+  = GDatatype (IR.Datatype' ext primTy primVal)
+  | GDataCon (IR.DataCon' ext primTy primVal)
+  | GFunction (IR.Function' ext primTy primVal)
+  | GAbstract IR.GlobalUsage (IR.Value' ext primTy primVal)
+  deriving ({-Show, Eq,-} Generic)
+
+type Global = Global' IR.NoExt
+
+type EnvAlias' ext primTy primVal =
   ExceptT
-    (TypecheckError primTy primVal)
-    (State (EnvCtx primTy primVal))
+    (TypecheckError' ext primTy primVal)
+    (State (EnvCtx' ext primTy primVal))
 
-newtype EnvTypecheck primTy primVal a = EnvTyp (EnvAlias primTy primVal a)
+newtype EnvTypecheck' ext primTy primVal a =
+    EnvTyp (EnvAlias' ext primTy primVal a)
   deriving (Functor, Applicative, Monad)
   deriving
-    ( HasThrow "typecheckError" (TypecheckError primTy primVal)
+    ( HasThrow "typecheckError" (TypecheckError' ext primTy primVal)
     )
-    via MonadError (EnvAlias primTy primVal)
+    via MonadError (EnvAlias' ext primTy primVal)
   deriving
-    ( HasSink "globals" (Globals primTy primVal),
-      HasState "globals" (Globals primTy primVal)
+    ( HasSource "globals" (Globals' ext primTy primVal),
+      HasReader "globals" (Globals' ext primTy primVal)
     )
-    via StateField "globals" (EnvAlias primTy primVal)
-  deriving
-    ( HasSource "globals" (Globals primTy primVal),
-      HasReader "globals" (Globals primTy primVal)
-    )
-    via ReaderField "globals" (EnvAlias primTy primVal)
+    via ReaderField "globals" (EnvAlias' ext primTy primVal)
+
+type EnvTypecheck = EnvTypecheck' IR.NoExt
+
+type HasGlobals' ext primTy primVal =
+  HasReader "globals" (Globals' ext primTy primVal)
+
+type HasGlobals primTy primVal = HasGlobals' IR.NoExt primTy primVal
+
+type CanTC' ext primTy primVal m =
+  (HasThrowTC' ext primTy primVal m,
+   HasGlobals' ext primTy primVal m)
+
+type CanTC primTy primVal m = CanTC' IR.NoExt primTy primVal m
 
 exec ::
   Globals primTy primVal ->
@@ -53,70 +71,126 @@ exec ::
 exec globals (EnvTyp env) =
   runState (runExceptT env) $ EnvCtx globals
 
-type Context primTy primVal = [Annotation primTy primVal]
+type Context' ext primTy primVal = [Annotation' ext primTy primVal]
+type Context primTy primVal = Context' IR.NoExt primTy primVal
 
 lookupCtx ::
-  Context primTy primVal ->
+  (IR.ValueAll Eval.HasWeak ext primTy primVal,
+   IR.NeutralAll Eval.HasWeak ext primTy primVal) =>
+  Context' ext primTy primVal ->
   IR.BoundVar ->
-  Maybe (Annotation primTy primVal)
+  Maybe (Annotation' ext primTy primVal)
 lookupCtx gam x = do
   Annotation π ty <- atMay gam (fromIntegral x)
   pure $ Annotation π (Eval.weakBy (x + 1) ty)
 
+lookupGlobal ::
+  (HasGlobals primTy primVal m, HasThrowTC primTy primVal m) =>
+  IR.GlobalName ->
+  m (IR.Value primTy primVal, IR.GlobalUsage)
+lookupGlobal x = do
+  mdefn <- asks @"globals" $ HashMap.lookup x
+  case mdefn of
+    Just defn -> pure $ makeGAnn defn
+    Nothing -> throwTC (UnboundGlobal x)
+  where
+    makeGAnn (GDatatype (IR.Datatype {dataArgs, dataLevel})) =
+      (foldr makePi (IR.VStar' dataLevel mempty) dataArgs, IR.GZero)
+    makeGAnn (GDataCon (IR.DataCon {conType})) =
+      (conType, IR.GOmega)
+    makeGAnn (GFunction (IR.Function {funType, funUsage})) =
+      (funType, funUsage)
+    makeGAnn (GAbstract absUsage absType) =
+      (absType, absUsage)
+    makePi (IR.DataArg {argUsage, argType}) res =
+      IR.VPi' argUsage argType res mempty
+
+primType :: HasReader "param" (Param.Parameterisation primTy primVal) m
+         => primVal -> m (IR.Value primTy primVal)
+primType v = do
+  asks @"param" \param ->
+    Param.typeOf param v
+      |> fmap IR.VPrimTy
+      |> foldr1 (IR.VPi Usage.Omega)
+
 type UContext primTy primVal = [Usage.T]
 
-type PatBinds primTy primVal = IntMap (Annotation primTy primVal)
+type PatBinds' ext primTy primVal = IntMap (Annotation' ext primTy primVal)
+type PatBinds primTy primVal = PatBinds' IR.NoExt primTy primVal
 
 type PatUsages primTy primVal = IntMap Usage.T
 
-data InnerState primTy primVal
+data InnerState' ext primTy primVal
   = InnerState
       { param :: Param.Parameterisation primTy primVal,
-        patBinds :: PatBinds primTy primVal,
-        bound :: Context primTy primVal
+        patBinds :: PatBinds' ext primTy primVal,
+        bound :: Context' ext primTy primVal
       }
   deriving (Generic)
 
-type InnerTCAlias primTy primVal =
-  StateT (InnerState primTy primVal) (EnvTypecheck primTy primVal)
+type InnerState = InnerState' IR.NoExt
 
-newtype InnerTC primTy primVal a
-  = InnerTC {unInnerTC :: InnerTCAlias primTy primVal a}
+type InnerTCAlias' ext primTy primVal =
+  StateT (InnerState' ext primTy primVal) (EnvTypecheck' ext primTy primVal)
+
+newtype InnerTC' ext primTy primVal a =
+    InnerTC (InnerTCAlias' ext primTy primVal a)
   deriving newtype (Functor, Applicative, Monad)
   deriving
-    ( HasThrow "typecheckError" (TypecheckError primTy primVal),
-      HasSink "globals" (Globals primTy primVal),
-      HasState "globals" (Globals primTy primVal),
-      HasSource "globals" (Globals primTy primVal),
-      HasReader "globals" (Globals primTy primVal)
+    ( HasThrow "typecheckError" (TypecheckError' ext primTy primVal),
+      HasSource "globals" (Globals' ext primTy primVal),
+      HasReader "globals" (Globals' ext primTy primVal)
     )
-    via Lift (InnerTCAlias primTy primVal)
+    via Lift (InnerTCAlias' ext primTy primVal)
   deriving
     ( HasSource "param" (Param.Parameterisation primTy primVal),
       HasReader "param" (Param.Parameterisation primTy primVal)
     )
-    via ReaderField "param" (InnerTCAlias primTy primVal)
+    via ReaderField "param" (InnerTCAlias' ext primTy primVal)
   deriving
-    ( HasSource "patBinds" (PatBinds primTy primVal),
-      HasSink "patBinds" (PatBinds primTy primVal),
-      HasState "patBinds" (PatBinds primTy primVal)
+    ( HasSource "patBinds" (PatBinds' ext primTy primVal),
+      HasSink "patBinds" (PatBinds' ext primTy primVal),
+      HasState "patBinds" (PatBinds' ext primTy primVal)
     )
-    via StateField "patBinds" (InnerTCAlias primTy primVal)
+    via StateField "patBinds" (InnerTCAlias' ext primTy primVal)
   deriving
-    ( HasSource "bound" (Context primTy primVal),
-      HasSink "bound" (Context primTy primVal),
-      HasState "bound" (Context primTy primVal)
+    ( HasSource "bound" (Context' ext primTy primVal),
+      HasSink "bound" (Context' ext primTy primVal),
+      HasState "bound" (Context' ext primTy primVal)
     )
-    via StateField "bound" (InnerTCAlias primTy primVal)
+    via StateField "bound" (InnerTCAlias' ext primTy primVal)
+
+type InnerTC = InnerTC' IR.NoExt
+
+type HasParam primTy primVal =
+  HasReader "param" (Param.Parameterisation primTy primVal)
+
+type HasPatBinds' ext primTy primVal =
+  HasState "patBinds" (PatBinds' ext primTy primVal)
+
+type HasPatBinds primTy primVal = HasPatBinds' IR.NoExt primTy primVal
+
+type HasBound' ext primTy primVal =
+  HasState "bound" (Context' ext primTy primVal)
+
+type HasBound primTy primVal = HasBound' IR.NoExt primTy primVal
+
+type CanInnerTC' ext primTy primVal m =
+  (CanTC' ext primTy primVal m,
+   HasParam primTy primVal m,
+   HasPatBinds' ext primTy primVal m,
+   HasBound' ext primTy primVal m)
+
+type CanInnerTC primTy primVal m = CanInnerTC' IR.NoExt primTy primVal m
 
 execInner ::
-  InnerTC primTy primVal a ->
-  InnerState primTy primVal ->
-  EnvTypecheck primTy primVal a
+  InnerTC' ext primTy primVal a ->
+  InnerState' ext primTy primVal ->
+  EnvTypecheck' ext primTy primVal a
 execInner (InnerTC m) = evalStateT m
 
 execInner' ::
-  InnerTC primTy primVal a ->
-  InnerState primTy primVal ->
-  EnvTypecheck primTy primVal (a, InnerState primTy primVal)
+  InnerTC' ext primTy primVal a ->
+  InnerState' ext primTy primVal ->
+  EnvTypecheck' ext primTy primVal (a, InnerState' ext primTy primVal)
 execInner' (InnerTC m) = runStateT m

--- a/src/Juvix/Core/IR/Typechecker/Env.hs
+++ b/src/Juvix/Core/IR/Typechecker/Env.hs
@@ -87,14 +87,6 @@ lookupGlobal x = do
     makePi (IR.DataArg {argUsage, argType}) res =
       IR.VPi' argUsage argType res mempty
 
-primType :: HasReader "param" (Param.Parameterisation primTy primVal) m
-         => primVal -> m (IR.Value primTy primVal)
-primType v = do
-  asks @"param" \param ->
-    Param.typeOf param v
-      |> fmap IR.VPrimTy
-      |> foldr1 (IR.VPi Usage.Omega)
-
 type UContext = [Usage.T]
 
 type PatBinds primTy primVal = IntMap (Annotation primTy primVal)

--- a/src/Juvix/Core/IR/Typechecker/Types.hs
+++ b/src/Juvix/Core/IR/Typechecker/Types.hs
@@ -65,7 +65,7 @@ data TypecheckError' extV extT primTy primVal
       { unboundPatVar :: IR.PatternVar
       }
   | NotPrimTy
-      { typeActual :: IR.Value' ext primTy primVal
+      { typeActual :: IR.Value' extV primTy primVal
       }
   | WrongPrimTy
       { primVal :: primVal,

--- a/src/Juvix/Core/IR/Typechecker/Types.hs
+++ b/src/Juvix/Core/IR/Typechecker/Types.hs
@@ -26,22 +26,22 @@ deriving instance
   (Show (IR.Value' ext primTy primVal)) =>
   Show (Annotation' ext primTy primVal)
 
-data TypecheckError' ext primTy primVal
+data TypecheckError' extV extT primTy primVal
   = TypeMismatch
-      { typeSubject :: IR.Elim' ext primTy primVal,
-        typeExpected, typeGot :: IR.Value' ext primTy primVal
+      { typeSubject :: IR.Elim' extT primTy primVal,
+        typeExpected, typeGot :: IR.Value' extV primTy primVal
       }
   | UniverseMismatch
       { universeLower, universeHigher :: IR.Universe
       }
   | CannotApply
-      { applyFun, applyArg :: IR.Value' ext primTy primVal
+      { applyFun, applyArg :: IR.Value' extV primTy primVal
       }
   | ShouldBeStar
-      { typeActual :: IR.Value' ext primTy primVal
+      { typeActual :: IR.Value' extV primTy primVal
       }
   | ShouldBeFunctionType
-      { typeActual :: IR.Value' ext primTy primVal
+      { typeActual :: IR.Value' extV primTy primVal
       }
   | UnboundIndex
       { unboundIndex :: IR.BoundVar
@@ -71,28 +71,47 @@ data TypecheckError' ext primTy primVal
       { primVal :: primVal,
         primTy :: P.PrimType primTy
       }
+  | UnsupportedTermExt
+      { termExt :: IR.TermX extT primTy primVal
+      }
+  | UnsupportedElimExt
+      { elimExt :: IR.ElimX extT primTy primVal
+      }
+  | PartiallyAppliedConstructor
+      { pattern_ :: IR.Pattern' extT primTy primVal
+      }
 
-type TypecheckError = TypecheckError' IR.NoExt
+type TypecheckError = TypecheckError' IR.NoExt IR.NoExt
 
 deriving instance
   ( Eq primTy,
     Eq primVal,
-    IR.TermAll Eq ext primTy primVal,
-    IR.ElimAll Eq ext primTy primVal,
-    IR.ValueAll Eq ext primTy primVal,
-    IR.NeutralAll Eq ext primTy primVal
+    IR.TermAll Eq extV primTy primVal,
+    IR.ElimAll Eq extV primTy primVal,
+    IR.ValueAll Eq extV primTy primVal,
+    IR.NeutralAll Eq extV primTy primVal,
+    IR.TermAll Eq extT primTy primVal,
+    IR.ElimAll Eq extT primTy primVal,
+    IR.ValueAll Eq extT primTy primVal,
+    IR.NeutralAll Eq extT primTy primVal,
+    IR.PatternAll Eq extT primTy primVal
   ) =>
-  Eq (TypecheckError' ext primTy primVal)
+  Eq (TypecheckError' extV extT primTy primVal)
 
 instance
   ( Show primTy,
     Show primVal,
-    IR.TermAll Show ext primTy primVal,
-    IR.ElimAll Show ext primTy primVal,
-    IR.ValueAll Show ext primTy primVal,
-    IR.NeutralAll Show ext primTy primVal
+    IR.TermAll Show extV primTy primVal,
+    IR.ElimAll Show extV primTy primVal,
+    IR.ValueAll Show extV primTy primVal,
+    IR.NeutralAll Show extV primTy primVal,
+    IR.TermAll Show extT primTy primVal,
+    IR.ElimAll Show extT primTy primVal,
+    IR.ValueAll Show extT primTy primVal,
+    IR.NeutralAll Show extT primTy primVal,
+    IR.PatternAll Show extT primTy primVal
   ) =>
-  Show (TypecheckError' ext primTy primVal)
+  Show (TypecheckError' extV extT primTy primVal)
   where
   show (TypeMismatch term expectedT gotT) =
     "Type mismatched.\n" <> show term <> "\n"
@@ -132,16 +151,22 @@ instance
     "Not a valid primitive type: " <> show x
   show (WrongPrimTy x ty) =
     "Primitive value " <> show x <> " cannot have type " <> show ty
+  show (UnsupportedTermExt x) =
+    "Unsupported syntax form " <> show x
+  show (UnsupportedElimExt x) =
+    "Unsupported syntax form " <> show x
+  show (PartiallyAppliedConstructor pat) =
+    "Partially-applied constructor in pattern " <> show pat
 
-type HasThrowTC' ext primTy primVal m =
-  HasThrow "typecheckError" (TypecheckError' ext primTy primVal) m
+type HasThrowTC' extV extT primTy primVal m =
+  HasThrow "typecheckError" (TypecheckError' extV extT primTy primVal) m
 
 type HasThrowTC primTy primVal m =
-  HasThrowTC' IR.NoExt primTy primVal m
+  HasThrowTC' IR.NoExt IR.NoExt primTy primVal m
 
 throwTC ::
-  HasThrowTC' ext primTy primVal m =>
-  TypecheckError' ext primTy primVal ->
+  HasThrowTC' extV extT primTy primVal m =>
+  TypecheckError' extV extT primTy primVal ->
   m z
 throwTC = throw @"typecheckError"
 

--- a/src/Juvix/Core/IR/Types.hs
+++ b/src/Juvix/Core/IR/Types.hs
@@ -24,17 +24,14 @@ extendValue "Value" [] [t|NoExt|] $ \_ _ -> defaultExtValue
 
 extendNeutral "Neutral" [] [t|NoExt|] $ \_ _ -> defaultExtNeutral
 
-extendDatatype "Datatype" [] [t|NoExt|] $ \_ _ -> defaultExtDatatype
-
-extendDataArg "DataArg" [] [t|NoExt|] $ \_ _ -> defaultExtDataArg
-
-extendDataCon "DataCon" [] [t|NoExt|] $ \_ _ -> defaultExtDataCon
-
-extendFunction "Function" [] [t|NoExt|] $ \_ _ -> defaultExtFunction
-
-extendFunClause "FunClause" [] [t|NoExt|] $ \_ _ -> defaultExtFunClause
-
 extendPattern "Pattern" [] [t|NoExt|] $ \_ _ -> defaultExtPattern
+
+type Datatype = Datatype' NoExt
+type DataArg = DataArg' NoExt
+type DataCon = DataCon' NoExt
+type Function = Function' NoExt
+type FunClause = FunClause' NoExt
+
 
 -- Quotation: takes a value back to a term
 quote0 :: Value primTy primVal -> Term primTy primVal

--- a/src/Juvix/Core/IR/Types.hs
+++ b/src/Juvix/Core/IR/Types.hs
@@ -8,6 +8,13 @@ module Juvix.Core.IR.Types
     PatternVar,
     BoundVar,
     Universe,
+    Datatype' (..),
+    DataArg' (..),
+    DataCon' (..),
+    Function' (..),
+    FunClause' (..),
+    Global' (..),
+    Globals',
   )
 where
 

--- a/src/Juvix/Core/IR/Types.hs
+++ b/src/Juvix/Core/IR/Types.hs
@@ -32,6 +32,8 @@ type DataCon = DataCon' NoExt
 type Function = Function' NoExt
 type FunClause = FunClause' NoExt
 
+type Global = Global' NoExt
+type Globals primTy primVal = Globals' NoExt primTy primVal
 
 -- Quotation: takes a value back to a term
 quote0 :: Value primTy primVal -> Term primTy primVal

--- a/src/Juvix/Core/IR/Types/Base.hs
+++ b/src/Juvix/Core/IR/Types/Base.hs
@@ -6,6 +6,8 @@ module Juvix.Core.IR.Types.Base where
 import Extensible
 import Juvix.Core.Usage
 import Juvix.Library
+import Juvix.Library.HashMap
+import Data.Kind (Constraint)
 
 type Universe = Natural
 
@@ -199,3 +201,27 @@ deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
 
 deriving instance GlobalAll NFData ext primTy primVal =>
   NFData (FunClause' ext primTy primVal)
+
+
+data Global' ext primTy primVal
+  = GDatatype (Datatype' ext primTy primVal)
+  | GDataCon (DataCon' ext primTy primVal)
+  | GFunction (Function' ext primTy primVal)
+  | GAbstract GlobalUsage (Value' ext primTy primVal)
+  deriving Generic
+
+deriving instance GlobalAll Eq ext primTy primVal =>
+  Eq (Global' ext primTy primVal)
+
+deriving instance GlobalAll Show ext primTy primVal =>
+  Show (Global' ext primTy primVal)
+
+deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
+  Data (Global' ext primTy primVal)
+
+deriving instance GlobalAll NFData ext primTy primVal =>
+  NFData (Global' ext primTy primVal)
+
+
+type Globals' ext primTy primVal =
+  HashMap GlobalName (Global' ext primTy primVal)

--- a/src/Juvix/Core/IR/Types/Base.hs
+++ b/src/Juvix/Core/IR/Types/Base.hs
@@ -78,46 +78,6 @@ extensible
       | NApp (Neutral primTy primVal) (Value primTy primVal)
       deriving (Eq, Show, Generic, Data, NFData)
 
-    data Datatype primTy primVal
-      = Datatype
-          { dataName :: GlobalName,
-            -- | the type constructor's arguments
-            dataArgs :: [DataArg primTy primVal],
-            -- | the type constructor's target universe level
-            dataLevel :: Natural,
-            dataCons :: [DataCon primTy primVal]
-          }
-      deriving (Show, Eq, Generic, Data, NFData)
-
-    data DataArg primTy primVal
-      = DataArg
-          { argName :: GlobalName,
-            argUsage :: Usage,
-            argType :: Value primTy primVal,
-            argIsParam :: Bool
-          }
-      deriving (Show, Eq, Generic, Data, NFData)
-
-    data DataCon primTy primVal
-      = DataCon
-          { conName :: GlobalName,
-            conType :: Value primTy primVal
-          }
-      deriving (Show, Eq, Generic, Data, NFData)
-
-    data Function primTy primVal
-      = Function
-          { funName :: GlobalName,
-            funUsage :: GlobalUsage,
-            funType :: Value primTy primVal,
-            funClauses :: NonEmpty (FunClause primTy primVal)
-          }
-      deriving (Show, Eq, Generic, Data, NFData)
-
-    data FunClause primTy primVal
-      = FunClause [Pattern primTy primVal] (Term primTy primVal)
-      deriving (Show, Eq, Generic, Data, NFData)
-
     data Pattern primTy primVal
       = PCon GlobalName [Pattern primTy primVal]
       | PVar PatternVar
@@ -125,3 +85,117 @@ extensible
       | PPrim primVal
       deriving (Show, Eq, Generic, Data, NFData)
     |]
+
+
+type GlobalAll (c :: * -> Constraint) ext primTy primVal =
+  (c primTy, c primVal,
+   TermAll c ext primTy primVal,
+   ElimAll c ext primTy primVal,
+   ValueAll c ext primTy primVal,
+   NeutralAll c ext primTy primVal,
+   PatternAll c ext primTy primVal)
+
+
+data Datatype' ext primTy primVal
+  = Datatype
+      { dataName :: GlobalName,
+        -- | the type constructor's arguments
+        dataArgs :: [DataArg' ext primTy primVal],
+        -- | the type constructor's target universe level
+        dataLevel :: Natural,
+        dataCons :: [DataCon' ext primTy primVal]
+      }
+  deriving Generic
+
+deriving instance GlobalAll Show ext primTy primVal =>
+  Show (Datatype' ext primTy primVal)
+
+deriving instance GlobalAll Eq ext primTy primVal =>
+  Eq (Datatype' ext primTy primVal)
+
+deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
+  Data (Datatype' ext primTy primVal)
+
+deriving instance GlobalAll NFData ext primTy primVal =>
+  NFData (Datatype' ext primTy primVal)
+
+
+data DataArg' ext primTy primVal
+  = DataArg
+      { argName :: GlobalName,
+        argUsage :: Usage,
+        argType :: Value' ext primTy primVal,
+        argIsParam :: Bool
+      }
+  deriving Generic
+
+deriving instance GlobalAll Show ext primTy primVal =>
+  Show (DataArg' ext primTy primVal)
+
+deriving instance GlobalAll Eq ext primTy primVal =>
+  Eq (DataArg' ext primTy primVal)
+
+deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
+  Data (DataArg' ext primTy primVal)
+
+deriving instance GlobalAll NFData ext primTy primVal =>
+  NFData (DataArg' ext primTy primVal)
+
+
+data DataCon' ext primTy primVal
+  = DataCon
+      { conName :: GlobalName,
+        conType :: Value' ext primTy primVal
+      }
+  deriving Generic
+
+deriving instance GlobalAll Show ext primTy primVal =>
+  Show (DataCon' ext primTy primVal)
+
+deriving instance GlobalAll Eq ext primTy primVal =>
+  Eq (DataCon' ext primTy primVal)
+
+deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
+  Data (DataCon' ext primTy primVal)
+
+deriving instance GlobalAll NFData ext primTy primVal =>
+  NFData (DataCon' ext primTy primVal)
+
+
+data Function' ext primTy primVal
+  = Function
+      { funName :: GlobalName,
+        funUsage :: GlobalUsage,
+        funType :: Value' ext primTy primVal,
+        funClauses :: NonEmpty (FunClause' ext primTy primVal)
+      }
+  deriving Generic
+
+deriving instance GlobalAll Show ext primTy primVal =>
+  Show (Function' ext primTy primVal)
+
+deriving instance GlobalAll Eq ext primTy primVal =>
+  Eq (Function' ext primTy primVal)
+
+deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
+  Data (Function' ext primTy primVal)
+
+deriving instance GlobalAll NFData ext primTy primVal =>
+  NFData (Function' ext primTy primVal)
+
+
+data FunClause' ext primTy primVal
+  = FunClause [Pattern' ext primTy primVal] (Term' ext primTy primVal)
+  deriving Generic
+
+deriving instance GlobalAll Show ext primTy primVal =>
+  Show (FunClause' ext primTy primVal)
+
+deriving instance GlobalAll Eq ext primTy primVal =>
+  Eq (FunClause' ext primTy primVal)
+
+deriving instance (Data ext, GlobalAll Data ext primTy primVal) =>
+  Data (FunClause' ext primTy primVal)
+
+deriving instance GlobalAll NFData ext primTy primVal =>
+  NFData (FunClause' ext primTy primVal)


### PR DESCRIPTION
Currently extensions are just rejected by the typechecker; a way to integrate them properly is still in progress