### PR TITLE
Move Prim to Term, allow multi-typed primitives, add `builtin` fields

### DIFF
--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
@@ -16,7 +16,8 @@ import Juvix.Core.Types hiding
     parseVal,
     reservedNames,
     reservedOpNames,
-    typeOf,
+    hasType,
+    arity,
   )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
@@ -97,6 +98,13 @@ typeOf Eq =
   BoolTy Booleans.Ty :| [FETy FieldElements.Ty, FETy FieldElements.Ty]
 typeOf (IntegerVal _) = undefined
 
+hasType :: Val -> PrimType Ty -> Bool
+hasType x ty = ty == typeOf x
+
+arity :: Val -> Int
+arity = length . typeOf
+
+
 apply :: Val -> Val -> Maybe Val
 apply (BoolVal x) (BoolVal y) =
   boolValToAll <$> Booleans.apply x y
@@ -127,17 +135,12 @@ reservedOpNames =
 
 t :: Parameterisation Ty Val
 t =
-  Parameterisation
-    { typeOf,
-      apply,
-      parseTy,
-      parseVal,
-      reservedNames,
-      reservedOpNames,
-      stringTy = \_ _ -> False,
-      stringVal = const Nothing,
-      intTy = \i _ -> False, -- TODO
-      intVal = const Nothing, -- TODO
-      floatTy = \_ _ -> False,
-      floatVal = const Nothing
-    }
+  Parameterisation {
+    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \i _ -> False, -- TODO
+    intVal = const Nothing, -- TODO
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
@@ -102,7 +102,7 @@ hasType :: Val -> PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val -> Int
-arity = length . typeOf
+arity = pred . length . typeOf
 
 
 apply :: Val -> Val -> Maybe Val

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns -Wwarn=missing-methods #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Juvix.Backends.ArithmeticCircuit.Parameterisation where
 
@@ -10,15 +11,6 @@ import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.Booleans as B
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements as FieldElements
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.Integers as FEInteger
 import qualified Juvix.Core.Parameterisation as P
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -87,7 +79,7 @@ feTyToAll = FETy
 feValToAll :: FEVal -> Val
 feValToAll = FEVal
 
-typeOf :: Val -> NonEmpty Ty
+typeOf :: Val -> P.PrimType Ty
 typeOf (BoolVal x) =
   fmap boolTyToAll (Booleans.typeOf x)
 typeOf (FEVal x) =
@@ -98,7 +90,7 @@ typeOf Eq =
   BoolTy Booleans.Ty :| [FETy FieldElements.Ty, FETy FieldElements.Ty]
 typeOf (IntegerVal _) = undefined
 
-hasType :: Val -> PrimType Ty -> Bool
+hasType :: Val -> P.PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val -> Int
@@ -133,10 +125,17 @@ reservedOpNames :: [String]
 reservedOpNames =
   Booleans.reservedOpNames <> FieldElements.reservedOpNames <> ["=="]
 
-t :: Parameterisation Ty Val
+builtinTypes :: P.Builtins Ty
+builtinTypes = [] -- FIXME
+
+builtinValues :: P.Builtins Val
+builtinValues = [] -- FIXME
+
+t :: P.Parameterisation Ty Val
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \i _ -> False, -- TODO

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
@@ -1,18 +1,10 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Juvix.Backends.ArithmeticCircuit.Parameterisation.Booleans where
 
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements as FieldElements
 import qualified Juvix.Core.Parameterisation as P
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -42,14 +34,14 @@ data Val f b where
   Not :: FieldT e b => Val (e f b) b
   Curried :: FieldT e b => Val (e f b) b -> e f b -> Val (e f b) b
 
-typeOf :: Val f b -> NonEmpty Ty
+typeOf :: Val f b -> P.PrimType Ty
 typeOf (Val _) = Ty :| []
 typeOf Or = Ty :| [Ty, Ty]
 typeOf And = Ty :| [Ty, Ty]
 typeOf Not = Ty :| [Ty, Ty]
 typeOf (Curried _ _) = Ty :| [Ty]
 
-hasType :: Val f b -> PrimType Ty -> Bool
+hasType :: Val f b -> P.PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val f b -> Int
@@ -93,10 +85,17 @@ reservedNames = ["Bool", "T", "F", "||", "&&"]
 reservedOpNames :: [String]
 reservedOpNames = []
 
-t :: FieldT e b => Parameterisation Ty (Val (e f b) b)
+builtinTypes :: P.Builtins Ty
+builtinTypes = [] -- FIXME
+
+builtinValues :: FieldT e b => P.Builtins (Val (e f b) b)
+builtinValues = [] -- FIXME
+
+t :: FieldT e b => P.Parameterisation Ty (Val (e f b) b)
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \_ _ -> False,

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
@@ -10,7 +10,8 @@ import Juvix.Core.Types hiding
     parseVal,
     reservedNames,
     reservedOpNames,
-    typeOf,
+    hasType,
+    arity,
   )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
@@ -47,6 +48,12 @@ typeOf Or = Ty :| [Ty, Ty]
 typeOf And = Ty :| [Ty, Ty]
 typeOf Not = Ty :| [Ty, Ty]
 typeOf (Curried _ _) = Ty :| [Ty]
+
+hasType :: Val f b -> PrimType Ty -> Bool
+hasType x ty = ty == typeOf x
+
+arity :: Val f b -> Int
+arity = length . typeOf
 
 apply :: FieldT e b => Val (e f b) b -> Val (e f b) b -> Maybe (Val (e f b) b)
 apply Or (Val x) = pure $ Curried Or x
@@ -88,17 +95,12 @@ reservedOpNames = []
 
 t :: FieldT e b => Parameterisation Ty (Val (e f b) b)
 t =
-  Parameterisation
-    { typeOf,
-      apply,
-      parseTy,
-      parseVal,
-      reservedNames,
-      reservedOpNames,
-      stringTy = \_ _ -> False,
-      stringVal = const Nothing,
-      intTy = \_ _ -> False,
-      intVal = const Nothing,
-      floatTy = \_ _ -> False,
-      floatVal = const Nothing
-    }
+  Parameterisation {
+    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Booleans.hs
@@ -53,7 +53,7 @@ hasType :: Val f b -> PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val f b -> Int
-arity = length . typeOf
+arity = pred . length . typeOf
 
 apply :: FieldT e b => Val (e f b) b -> Val (e f b) b -> Maybe (Val (e f b) b)
 apply Or (Val x) = pure $ Curried Or x

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
@@ -53,7 +53,7 @@ hasType :: Val a -> PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val a -> Int
-arity = length . typeOf
+arity = pred . length . typeOf
 
 apply :: FieldElement e => Val (e f f) -> Val (e f f) -> Maybe (Val (e f f))
 apply Add (Val x) = pure (Curried Add x)

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
@@ -9,7 +9,8 @@ import Juvix.Core.Types hiding
     parseVal,
     reservedNames,
     reservedOpNames,
-    typeOf,
+    hasType,
+    arity,
   )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
@@ -48,6 +49,12 @@ typeOf Neg = undefined
 typeOf IntExp = undefined
 typeOf Eq = undefined
 
+hasType :: Val a -> PrimType Ty -> Bool
+hasType x ty = ty == typeOf x
+
+arity :: Val a -> Int
+arity = length . typeOf
+
 apply :: FieldElement e => Val (e f f) -> Val (e f f) -> Maybe (Val (e f f))
 apply Add (Val x) = pure (Curried Add x)
 apply Mul (Val x) = pure (Curried Mul x)
@@ -71,17 +78,12 @@ reservedOpNames = []
 
 t :: FieldElement e => Parameterisation Ty (Val (e f f))
 t =
-  Parameterisation
-    { typeOf,
-      apply,
-      parseTy,
-      parseVal,
-      reservedNames,
-      reservedOpNames,
-      stringTy = \_ _ -> False,
-      stringVal = const Nothing,
-      intTy = \_ _ -> False,
-      intVal = const Nothing,
-      floatTy = \_ _ -> False,
-      floatVal = const Nothing
-    }
+  Parameterisation {
+    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/FieldElements.hs
@@ -1,17 +1,9 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
 
 module Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements where
 
 import qualified Juvix.Core.Parameterisation as P
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -40,7 +32,7 @@ data Val f where
   Eq :: FieldElement e => Val (e f g)
   Curried :: FieldElement e => Val (e f g) -> e f g -> Val (e f g)
 
-typeOf :: Val a -> NonEmpty Ty
+typeOf :: Val a -> P.PrimType Ty
 typeOf (Val _) = Ty :| []
 typeOf (Curried _ _) = Ty :| [Ty]
 typeOf Add = Ty :| [Ty, Ty]
@@ -49,7 +41,7 @@ typeOf Neg = undefined
 typeOf IntExp = undefined
 typeOf Eq = undefined
 
-hasType :: Val a -> PrimType Ty -> Bool
+hasType :: Val a -> P.PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val a -> Int
@@ -76,10 +68,17 @@ reservedNames = ["FieldElements", "F", "add", "mul"]
 reservedOpNames :: [String]
 reservedOpNames = []
 
-t :: FieldElement e => Parameterisation Ty (Val (e f f))
+builtinTypes :: P.Builtins Ty
+builtinTypes = [] -- FIXME
+
+builtinValues :: FieldElement e => P.Builtins (Val (e f f))
+builtinValues = [] -- FIXME
+
+t :: FieldElement e => P.Parameterisation Ty (Val (e f f))
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \_ _ -> False,

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
@@ -57,7 +57,7 @@ hasType :: Val f i -> PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val f i -> Int
-arity = length . typeOf
+arity = pred . length . typeOf
 
 apply :: FieldT e i => Val (e f i) i -> Val (e f i) i -> Maybe (Val (e f i) i)
 apply Add (Val x) = pure (Curried Add x)

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
@@ -10,7 +10,8 @@ import Juvix.Core.Types hiding
     parseVal,
     reservedNames,
     reservedOpNames,
-    typeOf,
+    hasType,
+    arity,
   )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
@@ -52,6 +53,12 @@ typeOf Exp = undefined
 typeOf Neg = undefined
 typeOf Eq = undefined
 
+hasType :: Val f i -> PrimType Ty -> Bool
+hasType x ty = ty == typeOf x
+
+arity :: Val f i -> Int
+arity = length . typeOf
+
 apply :: FieldT e i => Val (e f i) i -> Val (e f i) i -> Maybe (Val (e f i) i)
 apply Add (Val x) = pure (Curried Add x)
 apply Mul (Val x) = pure (Curried Mul x)
@@ -87,17 +94,12 @@ reservedOpNames = []
 
 t :: FieldT e i => Parameterisation Ty (Val (e f i) i)
 t =
-  Parameterisation
-    { typeOf,
-      apply,
-      parseTy,
-      parseVal,
-      reservedNames,
-      reservedOpNames,
-      stringTy = \_ _ -> False,
-      stringVal = const Nothing,
-      intTy = \i _ -> False, -- TODO
-      intVal = const Nothing, -- TODO
-      floatTy = \_ _ -> False,
-      floatVal = const Nothing
-    }
+  Parameterisation {
+    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \i _ -> False, -- TODO
+    intVal = const Nothing, -- TODO
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
+++ b/src/Juvix/Backends/ArithmeticCircuit/Parameterisation/Integers.hs
@@ -1,18 +1,10 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Juvix.Backends.ArithmeticCircuit.Parameterisation.Integers where
 
 import qualified Juvix.Backends.ArithmeticCircuit.Parameterisation.FieldElements as FieldElements
 import qualified Juvix.Core.Parameterisation as P
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -44,7 +36,7 @@ data Val f i where
   Eq :: FieldT e i => Val (e f i) i
   Curried :: FieldT e i => Val (e f i) i -> e f i -> Val (e f b) i
 
-typeOf :: Val f i -> NonEmpty Ty
+typeOf :: Val f i -> P.PrimType Ty
 typeOf (Val _) = Ty :| []
 typeOf (Curried _ _) = Ty :| [Ty]
 typeOf Add = Ty :| [Ty, Ty]
@@ -53,7 +45,7 @@ typeOf Exp = undefined
 typeOf Neg = undefined
 typeOf Eq = undefined
 
-hasType :: Val f i -> PrimType Ty -> Bool
+hasType :: Val f i -> P.PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
 arity :: Val f i -> Int
@@ -92,10 +84,18 @@ reservedNames = ["Int", "+", "-", "*"]
 reservedOpNames :: [String]
 reservedOpNames = []
 
-t :: FieldT e i => Parameterisation Ty (Val (e f i) i)
+builtinTypes :: P.Builtins Ty
+builtinTypes = [] -- FIXME
+
+builtinValues :: FieldT e i => P.Builtins (Val (e f i) i)
+builtinValues = [] -- FIXME
+
+
+t :: FieldT e i => P.Parameterisation Ty (Val (e f i) i)
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \i _ -> False, -- TODO

--- a/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Juvix.Backends.Michelson.Parameterisation
   ( module Juvix.Backends.Michelson.Parameterisation,
@@ -18,6 +19,7 @@ import qualified Juvix.Backends.Michelson.DSL.InstructionsEff as Run
 import qualified Juvix.Backends.Michelson.DSL.Interpret as Interpreter
 import qualified Juvix.Core.ErasedAnn.Prim as Prim
 import qualified Juvix.Core.Types as Core
+import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding (many, try)
 import qualified Michelson.Macro as M
 import qualified Michelson.Parser as M
@@ -34,11 +36,8 @@ typeOf :: PrimVal -> NonEmpty PrimTy
 typeOf (Constant v) = PrimTy (M.Type (constType v) "") :| []
 typeOf AddI = PrimTy (M.Type M.TInt "") :| [PrimTy (M.Type M.TInt ""), PrimTy (M.Type M.TInt "")]
 
-hasType :: PrimVal -> Core.PrimType PrimTy -> Bool
+hasType :: PrimVal -> P.PrimType PrimTy -> Bool
 hasType x ty = ty == typeOf x
-
-arity' :: PrimVal -> Int
-arity' = pred . length . typeOf
 
 -- constructTerm ∷ PrimVal → PrimTy
 -- constructTerm (PrimConst v) = (v, Usage.Omega, PrimTy (M.Type (constType v) ""))
@@ -162,12 +161,18 @@ checkIntType val (PrimTy (M.Type ty _)) = case ty of
   M.TInt -> True -- TODO bounds?
   _ -> False
 
+builtinTypes :: P.Builtins PrimTy
+builtinTypes = [] -- FIXME
+
+builtinValues :: P.Builtins PrimVal
+builtinValues = [] -- FIXME
+
 -- TODO: Figure out what the parser ought to do.
-michelson :: Core.Parameterisation PrimTy PrimVal
+michelson :: P.Parameterisation PrimTy PrimVal
 michelson =
-  Core.Parameterisation {
-    hasType, arity=arity', apply, parseTy, parseVal, reservedNames,
-    reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = checkStringType,
     stringVal = Just . Constant . M.ValueString . M.mkMTextUnsafe, -- TODO ?
     intTy = checkIntType,

--- a/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -38,7 +38,7 @@ hasType :: PrimVal -> Core.PrimType PrimTy -> Bool
 hasType x ty = ty == typeOf x
 
 arity' :: PrimVal -> Int
-arity' = length . typeOf
+arity' = pred . length . typeOf
 
 -- constructTerm ∷ PrimVal → PrimTy
 -- constructTerm (PrimConst v) = (v, Usage.Omega, PrimTy (M.Type (constType v) ""))

--- a/src/Juvix/Core/EAC/ConstraintGen.hs
+++ b/src/Juvix/Core/EAC/ConstraintGen.hs
@@ -132,7 +132,8 @@ boxAndTypeConstraint parameterisation parameterizedAssignment term = do
   addConstraint (EAC.Constraint (EAC.ConstraintVar 1 <$> path) (EAC.Gte 0))
   case term of
     Erased.Prim p ->
-      pure (EAC.RBang 0 (EAC.RPrim p), arrow (Core.typeOf parameterisation p))
+      pure (EAC.RBang 0 (EAC.RPrim p),
+            undefined {-arrow (Core.typeOf parameterisation p)-})
     Erased.Var sym -> do
       -- Boxing constraint.
       case varPaths Map.!? sym of
@@ -334,8 +335,9 @@ typChecker parameterisation t typAssign = EAC.runEither (() <$ rec' t typAssign)
       case assign Map.!? s of
         Just arg -> pure (newAssign, EAC.PArrT x arg bodyType)
         Nothing -> throw @"typ" EAC.MissingOverUse
-    rec' (EAC.RBang _bangVar (EAC.RPrim _p)) _assign =
-      pure (_assign, (arrow (Core.typeOf parameterisation _p)))
+    rec' (EAC.RBang _bangVar (EAC.RPrim _p)) assign =
+      pure (assign,
+            undefined {-arrow (Core.typeOf parameterisation _p)-})
 
 typCheckerErr ::
   forall primTy primVal.

--- a/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/src/Juvix/Core/Erasure/Algorithm.hs
@@ -138,6 +138,8 @@ eraseTerm ::
   m (Erasure.Term primTy primVal)
 eraseTerm t@(Typed.Star _ _) = throwEra $ Erasure.UnsupportedTermT t
 eraseTerm t@(Typed.PrimTy _ _) = throwEra $ Erasure.UnsupportedTermT t
+eraseTerm (Typed.Prim p ann) = do
+  Erasure.Prim p <$> eraseType (IR.annType ann)
 eraseTerm t@(Typed.Pi _ _ _ _) = throwEra $ Erasure.UnsupportedTermT t
 eraseTerm (Typed.Lam t anns) = do
   let ty@(IR.VPi π _ _) = IR.annType $ IR.baResAnn anns
@@ -170,8 +172,6 @@ eraseElim (Typed.Free (IR.Global x) ann) = do
 eraseElim e@(Typed.Free (IR.Pattern _) _) = do
   -- FIXME ??????
   throwEra $ Erasure.UnsupportedTermE e
-eraseElim (Typed.Prim p ann) = do
-  Erasure.Prim p <$> eraseType (IR.annType ann)
 eraseElim (Typed.App e s ann) = do
   let IR.VPi π _ _ = IR.annType $ IR.getElimAnn e
   e <- eraseElim e

--- a/src/Juvix/Core/HR/Parser.hs
+++ b/src/Juvix/Core/HR/Parser.hs
@@ -89,6 +89,9 @@ generateParser parameterisation =
       primTyTerm :: Parser (Term primTy primVal)
       primTyTerm = PrimTy |<< parseTy parameterisation lexer
       --
+      primTerm :: Parser (Term primTy primVal)
+      primTerm = Prim |<< parseVal parameterisation lexer
+      --
       sortTerm :: Parser (Term primTy primVal)
       sortTerm = do
         reserved "*"
@@ -120,15 +123,13 @@ generateParser parameterisation =
       --
       termOnly :: Parser (Term primTy primVal)
       termOnly =
-        parens termOnly <|> primTyTerm <|> sortTerm <|> piTerm <|> lamTerm
+        parens termOnly <|> primTyTerm <|> try primTerm
+          <|> sortTerm <|> piTerm <|> lamTerm
       --
       elimTerm :: Parser (Term primTy primVal)
       elimTerm = do
         elim <- elim
         pure (Elim elim)
-      --
-      primElim :: Parser (Elim primTy primVal)
-      primElim = Prim |<< parseVal parameterisation lexer
       --
       annElim :: Parser (Elim primTy primVal)
       annElim = do
@@ -148,7 +149,7 @@ generateParser parameterisation =
       elim = buildExpressionParser ops elim'
       --
       elim' :: Parser (Elim primTy primVal)
-      elim' = try primElim <|> annElim <|> varElim <|> parens elim
+      elim' = annElim <|> varElim <|> parens elim
       --
       parseWhole :: Parser a -> Parser a
       parseWhole p = do

--- a/src/Juvix/Core/HRAnn/Types.hs
+++ b/src/Juvix/Core/HRAnn/Types.hs
@@ -19,11 +19,11 @@ pattern Let π x s l b = Let0 π l b (LetAnnotation x s)
 
 pattern Elim π s t = Elim0 s (Annotation π t)
 
-{-# COMPLETE Star, PrimTy, Pi, Lam, Let, Elim #-}
+{-# COMPLETE Star, PrimTy, Prim, Pi, Lam, Let, Elim #-}
 
 IR.extendElim "Elim" [] [t|T|] extElim
 
 pattern App π s ts ρ t tt =
   App0 s t (AppAnnotation (Annotation π ts) (Annotation ρ tt))
 
-{-# COMPLETE Var, Prim, App, Ann #-}
+{-# COMPLETE Var, App, Ann #-}

--- a/src/Juvix/Core/IR/Evaluator.hs
+++ b/src/Juvix/Core/IR/Evaluator.hs
@@ -42,6 +42,8 @@ instance AllWeak ext primTy primVal => HasWeak (IR.Term' ext primTy primVal) whe
     IR.Star' u (weakBy' b i a)
   weakBy' b i (IR.PrimTy' p a) =
     IR.PrimTy' p (weakBy' b i a)
+  weakBy' b i (IR.Prim' p a) =
+    IR.Prim' p (weakBy' b i a)
   weakBy' b i (IR.Pi' π s t a) =
     IR.Pi' π (weakBy' b i s) (weakBy' b (succ i) t) (weakBy' b i a)
   weakBy' b i (IR.Lam' t a) =
@@ -61,8 +63,6 @@ instance AllWeak ext primTy primVal => HasWeak (IR.Elim' ext primTy primVal) whe
       a' = weakBy' b i a
   weakBy' b i (IR.Free' x a) =
     IR.Free' x (weakBy' b i a)
-  weakBy' b i (IR.Prim' p a) =
-    IR.Prim' p (weakBy' b i a)
   weakBy' b i (IR.App' s t a) =
     IR.App' (weakBy' b i s) (weakBy' b i t) (weakBy' b i a)
   weakBy' b i (IR.Ann' π s t l a) =
@@ -117,6 +117,8 @@ instance
     IR.Star' u (substWith w i e a)
   substWith w i e (IR.PrimTy' t a) =
     IR.PrimTy' t (substWith w i e a)
+  substWith w i e (IR.Prim' p a) =
+    IR.Prim' p (substWith w i e a)
   substWith w i e (IR.Pi' π s t a) =
     IR.Pi' π (substWith w i e s) (substWith (succ w) (succ i) e t) (substWith w i e a)
   substWith w i e (IR.Lam' t a) =
@@ -141,8 +143,6 @@ instance
       a' = substWith w i e a
   substWith w i e (IR.Free' x a) =
     IR.Free' x (substWith w i e a)
-  substWith w i e (IR.Prim' p a) =
-    IR.Prim' p (substWith w i e a)
   substWith w i e (IR.App' f s a) =
     IR.App' (substWith w i e f) (substWith w i e s) (substWith w i e a)
   substWith w i e (IR.Ann' π s t l a) =
@@ -339,6 +339,8 @@ evalTermWith _ _ (IR.Star' u _) =
   pure $ IR.VStar u
 evalTermWith _ _ (IR.PrimTy' p _) =
   pure $ IR.VPrimTy p
+evalTermWith _ _ (IR.Prim' p _) =
+  pure $ IR.VPrim p
 evalTermWith exts param (IR.Pi' π s t _) =
   IR.VPi π <$> evalTermWith exts param s <*> evalTermWith exts param t
 evalTermWith exts param (IR.Lam' t _) =
@@ -362,8 +364,6 @@ evalElimWith _ _ (IR.Bound' i _) =
   pure $ IR.VBound i
 evalElimWith _ _ (IR.Free' x _) =
   pure $ IR.VFree x
-evalElimWith _ _ (IR.Prim' p _) =
-  pure $ IR.VPrim p
 evalElimWith exts param (IR.App' s t _) =
   join $
     vapp param <$> evalElimWith exts param s

--- a/src/Juvix/Core/IR/Evaluator.hs
+++ b/src/Juvix/Core/IR/Evaluator.hs
@@ -428,6 +428,9 @@ instance HasWeak a => HasWeak (Maybe a)
 
 instance HasWeak a => HasWeak [a]
 
+instance HasWeak Symbol where
+  weakBy' _ _ x = x
+
 class GHasWeak f => GHasSubst ext primTy primVal f where
   gsubstWith ::
     -- | How many bindings have been traversed so far
@@ -503,6 +506,9 @@ instance
 instance
   HasSubst ext primTy primVal a =>
   HasSubst ext primTy primVal [a]
+
+instance HasSubst ext primTy primVal Symbol where
+  substWith _ _ _ x = x
 
 class GHasWeak f => GHasSubstV ext primTy primVal f where
   gsubstVWith ::
@@ -580,3 +586,6 @@ instance
 instance
   HasSubstV ext primTy primVal a =>
   HasSubstV ext primTy primVal [a]
+
+instance HasSubstV ext primTy primVal Symbol where
+  substVWith _ _ _ _ x = pure x

--- a/src/Juvix/Core/IR/TransformExt.hs
+++ b/src/Juvix/Core/IR/TransformExt.hs
@@ -12,13 +12,13 @@ data ExtTransformTEF f ext1 ext2 primTy primVal
   = ExtTransformTEF
       { etfStar :: XStar ext1 primTy primVal -> f (XStar ext2 primTy primVal),
         etfPrimTy :: XPrimTy ext1 primTy primVal -> f (XPrimTy ext2 primTy primVal),
+        etfPrim :: XPrim ext1 primTy primVal -> f (XPrim ext2 primTy primVal),
         etfPi :: XPi ext1 primTy primVal -> f (XPi ext2 primTy primVal),
         etfLam :: XLam ext1 primTy primVal -> f (XLam ext2 primTy primVal),
         etfLet :: XLet ext1 primTy primVal -> f (XLet ext2 primTy primVal),
         etfElim :: XElim ext1 primTy primVal -> f (XElim ext2 primTy primVal),
         etfBound :: XBound ext1 primTy primVal -> f (XBound ext2 primTy primVal),
         etfFree :: XFree ext1 primTy primVal -> f (XFree ext2 primTy primVal),
-        etfPrim :: XPrim ext1 primTy primVal -> f (XPrim ext2 primTy primVal),
         etfApp :: XApp ext1 primTy primVal -> f (XApp ext2 primTy primVal),
         etfAnn :: XAnn ext1 primTy primVal -> f (XAnn ext2 primTy primVal),
         etfTermX :: TermX ext1 primTy primVal -> f (TermX ext2 primTy primVal),
@@ -36,13 +36,13 @@ pattern Coerce f <-
 pattern ExtTransformTE ::
   (XStar ext1 primTy primVal -> XStar ext2 primTy primVal) ->
   (XPrimTy ext1 primTy primVal -> XPrimTy ext2 primTy primVal) ->
+  (XPrim ext1 primTy primVal -> XPrim ext2 primTy primVal) ->
   (XPi ext1 primTy primVal -> XPi ext2 primTy primVal) ->
   (XLam ext1 primTy primVal -> XLam ext2 primTy primVal) ->
   (XLet ext1 primTy primVal -> XLet ext2 primTy primVal) ->
   (XElim ext1 primTy primVal -> XElim ext2 primTy primVal) ->
   (XBound ext1 primTy primVal -> XBound ext2 primTy primVal) ->
   (XFree ext1 primTy primVal -> XFree ext2 primTy primVal) ->
-  (XPrim ext1 primTy primVal -> XPrim ext2 primTy primVal) ->
   (XApp ext1 primTy primVal -> XApp ext2 primTy primVal) ->
   (XAnn ext1 primTy primVal -> XAnn ext2 primTy primVal) ->
   (TermX ext1 primTy primVal -> TermX ext2 primTy primVal) ->
@@ -51,13 +51,13 @@ pattern ExtTransformTE ::
 pattern ExtTransformTE
   { etStar,
     etPrimTy,
+    etPrim,
     etPi,
     etLam,
     etLet,
     etElim,
     etBound,
     etFree,
-    etPrim,
     etApp,
     etAnn,
     etTermX,
@@ -66,13 +66,13 @@ pattern ExtTransformTE
   ExtTransformTEF
     { etfStar = Coerce etStar,
       etfPrimTy = Coerce etPrimTy,
+      etfPrim = Coerce etPrim,
       etfPi = Coerce etPi,
       etfLam = Coerce etLam,
       etfLet = Coerce etLet,
       etfElim = Coerce etElim,
       etfBound = Coerce etBound,
       etfFree = Coerce etFree,
-      etfPrim = Coerce etPrim,
       etfApp = Coerce etApp,
       etfAnn = Coerce etAnn,
       etfTermX = Coerce etTermX,
@@ -86,6 +86,7 @@ extTransformTF ::
   f (Term' ext2 primTy primVal)
 extTransformTF fs (Star' i e) = Star' i <$> etfStar fs e
 extTransformTF fs (PrimTy' k e) = PrimTy' k <$> etfPrimTy fs e
+extTransformTF fs (Prim' k e) = Prim' k <$> etfPrim fs e
 extTransformTF fs (Pi' π s t e) =
   Pi' π <$> extTransformTF fs s <*> extTransformTF fs t <*> etfPi fs e
 extTransformTF fs (Lam' t e) = Lam' <$> extTransformTF fs t <*> etfLam fs e
@@ -107,7 +108,6 @@ extTransformEF ::
   f (Elim' ext2 primTy primVal)
 extTransformEF fs (Bound' x e) = Bound' x <$> etfBound fs e
 extTransformEF fs (Free' x e) = Free' x <$> etfFree fs e
-extTransformEF fs (Prim' k e) = Prim' k <$> etfPrim fs e
 extTransformEF fs (App' f s e) =
   App' <$> extTransformEF fs f
     <*> extTransformTF fs s
@@ -134,13 +134,13 @@ forgetter =
   ExtTransformTE
     { etStar = const (),
       etPrimTy = const (),
+      etPrim = const (),
       etPi = const (),
       etLam = const (),
       etLet = const (),
       etElim = const (),
       etBound = const (),
       etFree = const (),
-      etPrim = const (),
       etApp = const (),
       etAnn = const (),
       etTermX = absurd,

--- a/src/Juvix/Core/IR/Types.hs
+++ b/src/Juvix/Core/IR/Types.hs
@@ -45,7 +45,7 @@ quote _ (VStar nat) = Star nat
 quote _ (VPrimTy p) = PrimTy p
 quote ii (VPi π s t) = Pi π (quote ii s) (quote (ii + 1) t)
 quote ii (VLam s) = Lam (quote (ii + 1) s)
-quote _ (VPrim pri) = Elim (Prim pri)
+quote _ (VPrim pri) = Prim pri
 quote ii (VNeutral n) = Elim $ neutralQuote ii n
 
 neutralQuote :: BoundVar -> Neutral primTy primVal -> Elim primTy primVal

--- a/src/Juvix/Core/IR/Types/Base.hs
+++ b/src/Juvix/Core/IR/Types/Base.hs
@@ -32,6 +32,8 @@ extensible
         Star Universe
       | -- | PrimTy primitive type
         PrimTy primTy
+      | -- | primitive constant
+        Prim primVal
       | -- | formation rule of the dependent function type PI.
         -- the Usage(π) tracks how many times x is used.
         Pi Usage (Term primTy primVal) (Term primTy primVal)
@@ -52,8 +54,6 @@ extensible
         Bound BoundVar
       | -- | Free variables of type name (see above)
         Free Name
-      | -- | primitive constant
-        Prim primVal
       | -- | elimination rule of PI (APP).
         App (Elim primTy primVal) (Term primTy primVal)
       | -- | Annotation with usage.

--- a/src/Juvix/Core/IRAnn/Types.hs
+++ b/src/Juvix/Core/IRAnn/Types.hs
@@ -26,7 +26,7 @@ pattern Lam π s t = Lam0 t (Annotation π s)
 
 pattern Elim π s t = Elim0 s (Annotation π t)
 
-{-# COMPLETE Star, PrimTy, Pi, Lam, Elim #-}
+{-# COMPLETE Star, PrimTy, Prim, Pi, Lam, Elim #-}
 
 data AppAnnotation primTy primVal
   = AppAnnotation
@@ -44,4 +44,4 @@ IR.extendElim "Elim" [] [t|T|] $
 pattern App π s ts ρ t tt =
   App0 s t (AppAnnotation (Annotation π ts) (Annotation ρ tt))
 
-{-# COMPLETE Bound, Free, Prim, App, Ann #-}
+{-# COMPLETE Bound, Free, App, Ann #-}

--- a/src/Juvix/Core/Parameterisation.hs
+++ b/src/Juvix/Core/Parameterisation.hs
@@ -5,10 +5,14 @@ import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
 import Prelude (String)
 
+-- | @[A, B, ..., Z]@ represents the type
+-- @π A -> ρ B -> ... -> Z@ for any usages @π@, @ρ@
+type PrimType primTy = NonEmpty primTy
+
 data Parameterisation primTy primVal
   = Parameterisation
-      { -- Returns an arrow.
-        typeOf :: primVal -> NonEmpty primTy,
+      { hasType :: primVal -> PrimType primTy -> Bool,
+        arity :: primVal -> Int,
         apply :: primVal -> primVal -> Maybe primVal,
         parseTy :: Token.GenTokenParser String () Identity -> Parser primTy,
         parseVal :: Token.GenTokenParser String () Identity -> Parser primVal,
@@ -22,6 +26,3 @@ data Parameterisation primTy primVal
         floatVal :: Double -> Maybe primVal
       }
   deriving (Generic)
-
-arity :: Parameterisation primTy primVal -> primVal -> Int
-arity param = length . typeOf param

--- a/src/Juvix/Core/Parameterisation.hs
+++ b/src/Juvix/Core/Parameterisation.hs
@@ -1,6 +1,8 @@
 module Juvix.Core.Parameterisation where
 
 import Juvix.Library
+import Juvix.Library.HashMap (HashMap)
+import Juvix.Frontend.Types.Base (NameSymb)
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
 import Prelude (String)
@@ -9,11 +11,17 @@ import Prelude (String)
 -- @π A -> ρ B -> ... -> Z@ for any usages @π@, @ρ@
 type PrimType primTy = NonEmpty primTy
 
+type Builtins p = HashMap NameSymb p
+
 data Parameterisation primTy primVal
   = Parameterisation
       { hasType :: primVal -> PrimType primTy -> Bool,
         arity :: primVal -> Int,
         apply :: primVal -> primVal -> Maybe primVal,
+
+        builtinTypes :: Builtins primTy,
+        builtinValues :: Builtins primVal,
+
         parseTy :: Token.GenTokenParser String () Identity -> Parser primTy,
         parseVal :: Token.GenTokenParser String () Identity -> Parser primVal,
         reservedNames :: [String],

--- a/src/Juvix/Core/Parameterisations/All.hs
+++ b/src/Juvix/Core/Parameterisations/All.hs
@@ -4,15 +4,6 @@ module Juvix.Core.Parameterisations.All where
 import qualified Juvix.Core.Parameterisation as P
 import qualified Juvix.Core.Parameterisations.Naturals as Naturals
 import qualified Juvix.Core.Parameterisations.Unit as Unit
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -50,7 +41,7 @@ unUnitTy :: Ty -> Maybe Unit.Ty
 unUnitTy (UnitTy t) = pure t
 unUnitTy _         = empty
 
-hasType :: Val -> PrimType Ty -> Bool
+hasType :: Val -> P.PrimType Ty -> Bool
 hasType (NatVal x)  (traverse unNatTy  -> Just tys) = Naturals.hasType x tys
 hasType (UnitVal x) (traverse unUnitTy -> Just tys) = Unit.hasType x tys
 hasType _           _                               = False
@@ -79,10 +70,21 @@ reservedNames = Naturals.reservedNames <> Unit.reservedNames
 reservedOpNames :: [String]
 reservedOpNames = Naturals.reservedOpNames <> Unit.reservedOpNames
 
-t :: Parameterisation Ty Val
+builtinTypes :: P.Builtins Ty
+builtinTypes =
+  fmap NatTy Naturals.builtinTypes <>
+  fmap UnitTy Unit.builtinTypes
+
+builtinValues :: P.Builtins Val
+builtinValues =
+  fmap NatVal Naturals.builtinValues <>
+  fmap UnitVal Unit.builtinValues
+
+t :: P.Parameterisation Ty Val
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \i _ -> Naturals.isNat i,

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -1,15 +1,8 @@
+{-# LANGUAGE OverloadedLists #-}
+
 module Juvix.Core.Parameterisations.Naturals where
 
 import qualified Juvix.Core.Parameterisation as P
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>), natVal)
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -37,15 +30,15 @@ instance Show Val where
   show Mul = "mul"
   show (Curried x y) = Juvix.Library.show x <> " " <> Text.Show.show y
 
-typeOf :: Val -> PrimType Ty
+typeOf :: Val -> P.PrimType Ty
 typeOf (Val _) = Ty :| []
 typeOf (Curried _ _) = Ty :| [Ty]
 typeOf Add = Ty :| [Ty, Ty]
 typeOf Sub = Ty :| [Ty, Ty]
 typeOf Mul = Ty :| [Ty, Ty]
 
-hasType :: Val -> PrimType Ty -> Bool
-hasType x ty = ty == typeOf x where
+hasType :: Val -> P.PrimType Ty -> Bool
+hasType x ty = ty == typeOf x
 
 arity :: Val -> Int
 arity = pred . length . typeOf
@@ -92,10 +85,17 @@ isNat i = i >= 0
 natVal :: Integer -> Maybe Val
 natVal i = if i >= 0 then Just (Val (fromIntegral i)) else Nothing
 
-t :: Parameterisation Ty Val
+builtinTypes :: P.Builtins Ty
+builtinTypes = [(["Nat"], Ty)]
+
+builtinValues :: P.Builtins Val
+builtinValues = [(["add"], Add), (["sub"], Sub), (["mul"], Mul)]
+
+t :: P.Parameterisation Ty Val
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, builtinTypes, builtinValues, arity, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \i _ -> isNat i,

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -32,9 +32,9 @@ data Val
 
 instance Show Val where
   show (Val x) = "Nat " <> Text.Show.show x
-  show Add = "+"
-  show Sub = "-"
-  show Mul = "*"
+  show Add = "add"
+  show Sub = "sub"
+  show Mul = "mul"
   show (Curried x y) = Juvix.Library.show x <> " " <> Text.Show.show y
 
 typeOf :: Val -> PrimType Ty
@@ -72,16 +72,16 @@ parseNat :: Token.GenTokenParser String () Identity -> Parser Val
 parseNat lexer = Val . fromIntegral |<< Token.natural lexer
 
 parseAdd :: Token.GenTokenParser String () Identity -> Parser Val
-parseAdd lexer = Token.reserved lexer "+" >> pure Add
+parseAdd lexer = Token.reserved lexer "add" >> pure Add
 
 parseSub :: Token.GenTokenParser String () Identity -> Parser Val
-parseSub lexer = Token.reserved lexer "-" >> pure Sub
+parseSub lexer = Token.reserved lexer "sub" >> pure Sub
 
 parseMul :: Token.GenTokenParser String () Identity -> Parser Val
-parseMul lexer = Token.reserved lexer "*" >> pure Mul
+parseMul lexer = Token.reserved lexer "mul" >> pure Mul
 
 reservedNames :: [String]
-reservedNames = ["Nat", "+", "-", "*"]
+reservedNames = ["Nat", "add", "sub", "mul"]
 
 reservedOpNames :: [String]
 reservedOpNames = []

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -48,7 +48,7 @@ hasType :: Val -> PrimType Ty -> Bool
 hasType x ty = ty == typeOf x where
 
 arity :: Val -> Int
-arity = length . typeOf
+arity = pred . length . typeOf
 
 apply :: Val -> Val -> Maybe Val
 apply Add (Val x) = pure (Curried Add x)

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -7,7 +7,8 @@ import Juvix.Core.Types hiding
     parseVal,
     reservedNames,
     reservedOpNames,
-    typeOf,
+    hasType,
+    arity,
   )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
@@ -24,8 +25,12 @@ data Val
   = Val
   deriving (Show, Eq)
 
-typeOf :: Val -> NonEmpty Ty
-typeOf Val = Ty :| []
+hasType :: Val -> PrimType Ty -> Bool
+hasType Val (Ty :| []) = True
+hasType _ _ = False
+
+arity :: Val -> Int
+arity Val = 1
 
 apply :: Val -> Val -> Maybe Val
 apply _ _ = Nothing
@@ -48,17 +53,12 @@ reservedOpNames = []
 
 t :: Parameterisation Ty Val
 t =
-  Parameterisation
-    { typeOf,
-      apply,
-      parseTy,
-      parseVal,
-      reservedNames,
-      reservedOpNames,
-      stringTy = \_ _ -> False,
-      stringVal = const Nothing,
-      intTy = \_ _ -> False,
-      intVal = const Nothing,
-      floatTy = \_ _ -> False,
-      floatVal = const Nothing
-    }
+  Parameterisation {
+    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -1,15 +1,7 @@
+{-# LANGUAGE DisambiguateRecordFields, OverloadedLists #-}
 module Juvix.Core.Parameterisations.Unit where
 
 import qualified Juvix.Core.Parameterisation as P
-import Juvix.Core.Types hiding
-  ( apply,
-    parseTy,
-    parseVal,
-    reservedNames,
-    reservedOpNames,
-    hasType,
-    arity,
-  )
 import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -25,7 +17,7 @@ data Val
   = Val
   deriving (Show, Eq)
 
-hasType :: Val -> PrimType Ty -> Bool
+hasType :: Val -> P.PrimType Ty -> Bool
 hasType Val (Ty :| []) = True
 hasType _ _ = False
 
@@ -51,10 +43,17 @@ reservedNames = ["Unit", "tt"]
 reservedOpNames :: [String]
 reservedOpNames = []
 
-t :: Parameterisation Ty Val
+builtinTypes :: P.Builtins Ty
+builtinTypes = [(["Unit"], Ty)]
+
+builtinValues :: P.Builtins Val
+builtinValues = [(["tt"], Val)]
+
+t :: P.Parameterisation Ty Val
 t =
-  Parameterisation {
-    hasType, arity, apply, parseTy, parseVal, reservedNames, reservedOpNames,
+  P.Parameterisation {
+    hasType, arity, builtinTypes, builtinValues, apply,
+    parseTy, parseVal, reservedNames, reservedOpNames,
     stringTy = \_ _ -> False,
     stringVal = const Nothing,
     intTy = \_ _ -> False,

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -42,11 +42,11 @@ parseTy lexer = do
 
 parseVal :: Token.GenTokenParser String () Identity -> Parser Val
 parseVal lexer = do
-  Token.reserved lexer "()"
+  Token.reserved lexer "tt"
   pure Val
 
 reservedNames :: [String]
-reservedNames = ["Unit", "()"]
+reservedNames = ["Unit", "tt"]
 
 reservedOpNames :: [String]
 reservedOpNames = []

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -30,7 +30,7 @@ hasType Val (Ty :| []) = True
 hasType _ _ = False
 
 arity :: Val -> Int
-arity Val = 1
+arity Val = 0
 
 apply :: Val -> Val -> Maybe Val
 apply _ _ = Nothing

--- a/src/Juvix/Core/Translate.hs
+++ b/src/Juvix/Core/Translate.hs
@@ -18,6 +18,7 @@ hrToIR' term =
   case term of
     HR.Star n -> pure (IR.Star n)
     HR.PrimTy p -> pure (IR.PrimTy p)
+    HR.Prim p -> pure (IR.Prim p)
     HR.Pi u n a b -> do
       a <- hrToIR' a
       b <- withName n $ hrToIR' b
@@ -42,7 +43,6 @@ hrElimToIR' elim =
       pure $ case maybeIndex of
         Just ind -> IR.Bound (fromIntegral ind)
         Nothing -> IR.Free (IR.Global n)
-    HR.Prim p -> pure (IR.Prim p)
     HR.App f x -> do
       f <- hrElimToIR' f
       x <- hrToIR' x
@@ -65,6 +65,7 @@ irToHR' term =
   case term of
     IR.Star n -> pure (HR.Star n)
     IR.PrimTy p -> pure (HR.PrimTy p)
+    IR.Prim p -> pure (HR.Prim p)
     IR.Pi u a b -> do
       a <- irToHR' a
       n <- newName
@@ -93,7 +94,6 @@ irElimToHR' elim =
     IR.Bound i -> do
       v <- unDeBruijin (fromIntegral i)
       pure (HR.Var v)
-    IR.Prim p -> pure (HR.Prim p)
     IR.App f x -> do
       f <- irElimToHR' f
       x <- irToHR' x

--- a/src/Juvix/Interpreter/InteractionNet/Translation.hs
+++ b/src/Juvix/Interpreter/InteractionNet/Translation.hs
@@ -68,7 +68,7 @@ astToNet parameterisation bohm customSymMap = net'
     Env {net'} = execEnvState (recursive bohm Map.empty) (Env 0 empty mempty)
     -- we return the port which the node above it in the AST connects to!
     recursive (Type.Prim p) _context = do
-      let arity = Core.arity parameterisation p - 1
+      let arity = Core.arity parameterisation p
       case arity of
         0 -> (,) <$> newNode (AST.Primar $ AST.PrimVal p) <*> pure Prim
         1 -> do

--- a/src/Juvix/Library.hs
+++ b/src/Juvix/Library.hs
@@ -121,7 +121,7 @@ instance Show (a -> b) where
 
 newtype Symbol = Sym Text
   deriving newtype (Eq, Hashable, Semigroup, Ord, NFData)
-  deriving stock (Data)
+  deriving stock (Data, Generic)
 
 instance Show Symbol where
   show (Sym t) = T.unpack t

--- a/test/Core/EAC2.hs
+++ b/test/Core/EAC2.hs
@@ -23,6 +23,8 @@ unitParam =
     hasType = \_ ty -> ty == () :| [],
     arity = const 0,
     apply = \_ _ -> Nothing,
+    builtinTypes = mempty,
+    builtinValues = mempty,
     parseTy = const empty,
     parseVal = const empty,
     reservedNames = [],

--- a/test/Core/EAC2.hs
+++ b/test/Core/EAC2.hs
@@ -19,20 +19,21 @@ type TypeAssignment = ET.TypeAssignment ()
 
 unitParam :: Types.Parameterisation () ()
 unitParam =
-  Types.Parameterisation
-    { typeOf = const $ () :| [],
-      apply = \_ _ -> Nothing,
-      parseTy = const empty,
-      parseVal = const empty,
-      reservedNames = [],
-      reservedOpNames = [],
-      stringTy = \_ _ -> False,
-      stringVal = const Nothing,
-      intTy = \_ _ -> False,
-      intVal = const Nothing,
-      floatTy = \_ _ -> False,
-      floatVal = const Nothing
-    }
+  Types.Parameterisation {
+    hasType = \_ ty -> ty == () :| [],
+    arity = const 0,
+    apply = \_ _ -> Nothing,
+    parseTy = const empty,
+    parseVal = const empty,
+    reservedNames = [],
+    reservedOpNames = [],
+    stringTy = \_ _ -> False,
+    stringVal = const Nothing,
+    intTy = \_ _ -> False,
+    intVal = const Nothing,
+    floatTy = \_ _ -> False,
+    floatVal = const Nothing
+  }
 
 shouldGen ::
   T.TestName ->

--- a/test/Core/Erasure.hs
+++ b/test/Core/Erasure.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fdefer-typed-holes #-}
-
 module Core.Erasure where
 
 import qualified Juvix.Core.Erased as Erased
@@ -80,7 +78,7 @@ identityUnit =
   shouldEraseTo
     "identityUnit"
     Unit.t
-    (Typed.Elim (Typed.Prim Unit.Val unitAnn) unitAnn, one)
+    (Typed.Prim Unit.Val unitAnn, one)
     (Erased.Prim Unit.Val)
 
 constUnit :: T.TestTree
@@ -221,7 +219,7 @@ constTy2T :: Typed.Term Unit.Ty Unit.Val
 constTy2T = Typed.Pi mempty identityTyT identityTyT (zeroAnn $ IR.VStar 0)
 
 unitTerm :: Typed.Term Unit.Ty Unit.Val
-unitTerm = Typed.Elim unitElim unitAnn
+unitTerm = Typed.Prim Unit.Val unitAnn
 
 unitElim :: Typed.Elim Unit.Ty Unit.Val
-unitElim = Typed.Prim Unit.Val unitAnn
+unitElim = Typed.Ann Usage.Omega unitTerm unitTyT 0 unitAnn

--- a/test/Core/Parser.hs
+++ b/test/Core/Parser.hs
@@ -46,7 +46,7 @@ coreParser =
       shouldParse "(* 1)" (Star 1),
       shouldParsePrim Nat.t "Nat" (PrimTy Nat.Ty),
       shouldParsePrim Unit.t "Unit" (PrimTy Unit.Ty),
-      shouldParsePrim Unit.t "()" (Elim (Prim Unit.Val)),
+      shouldParsePrim Unit.t "tt" (Prim Unit.Val),
       shouldParse "[Π] 1 A * 0 * 0" (Pi one "A" (Star 0) (Star 0)),
       shouldParse "\\x -> x" (Lam "x" (Elim (Var "x"))),
       shouldParse "\\x -> y" (Lam "x" (Elim (Var "y"))),
@@ -54,7 +54,7 @@ coreParser =
       shouldParse
         "\\x -> \\y -> x y"
         (Lam "x" (Lam "y" (Elim (App (Var "x") (Elim (Var "y")))))),
-      shouldParse "3" (Elim (Prim (Nat.Val 3))),
+      shouldParse "3" (Prim (Nat.Val 3)),
       shouldParse "xyz" (Elim (Var "xyz")),
       shouldParse "fun var" (Elim (App (Var "fun") (Elim (Var "var")))),
       shouldParse "(fun var)" (Elim (App (Var "fun") (Elim (Var "var")))),
@@ -68,7 +68,11 @@ coreParser =
       shouldParse
         "(@ (\\x -> x) : w (* 0) | 0) y"
         (Elim (App (Ann Usage.Omega (Lam "x" (Elim (Var "x"))) (Star 0) 0) (Elim (Var "y")))),
-      shouldParse "(2)" (Elim (Prim (Nat.Val 2))),
+      shouldParse "(2)" (Prim (Nat.Val 2)),
+      shouldParse "add" (Prim (Nat.Add))
+      {-,
+      -- these tests no longer work now primitives are terms
+      -- they'd have to be something like ((@ + : w ([Π] ...)) 3 4)
       shouldParse
         "(+ 3 4)"
         (Elim (App (App (Prim Nat.Add) (Elim (Prim (Nat.Val 3)))) (Elim (Prim (Nat.Val 4))))),
@@ -78,6 +82,7 @@ coreParser =
       shouldParse
         "(* 4 3)"
         (Elim (App (App (Prim Nat.Mul) (Elim (Prim (Nat.Val 4)))) (Elim (Prim (Nat.Val 3)))))
+      -}
     ]
 -- TODO: Fix this; currently only applications of eliminations can be parsed.
 -- shouldParse "(\\x -> x) y" (Elim (App (Lam "x" (Elim (Var "x"))) (Elim (Var "y"))))

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -164,25 +164,33 @@ test_partial_erase =
     (EmptyInstr (MT.Seq (MT.Nested (MT.PUSH (MT.VInt 12))) MT.Nop))
 
 twoTerm :: HR.Term PrimTy PrimVal
-twoTerm = HR.Elim (HR.Prim (Constant (M.ValueInt 2)))
+twoTerm = HR.Prim (Constant (M.ValueInt 2))
 
 erasedLamTerm :: HR.Term PrimTy PrimVal
-erasedLamTerm = HR.Lam "x" (HR.Elim (HR.Prim (Constant (M.ValueInt 2))))
+erasedLamTerm = HR.Lam "x" (HR.Prim (Constant (M.ValueInt 2)))
 
 erasedLamTy :: HR.Term PrimTy PrimVal
 erasedLamTy = HR.Pi (Usage.SNat 0) "x" intTy intTy
 
 appLam :: HR.Term PrimTy PrimVal
-appLam = HR.Elim (HR.App (HR.App (HR.Ann (Usage.SNat 1) lamTerm lamTy 0) (HR.Elim (HR.Prim (Constant (M.ValueInt 2))))) (HR.Elim (HR.Prim (Constant (M.ValueInt 3)))))
+appLam = HR.Elim (HR.App (HR.App (HR.Ann (Usage.SNat 1) lamTerm lamTy 0) (HR.Prim (Constant (M.ValueInt 2)))) (HR.Prim (Constant (M.ValueInt 3))))
+
+addTyT :: HR.Term PrimTy PrimVal
+addTyT = HR.Pi one "x" int $ HR.Pi one "y" int $ int where
+  one = Usage.SNat 1
+  int = HR.PrimTy $ PrimTy $ M.Type M.TInt M.noAnn
+
+addElim :: HR.Elim PrimTy PrimVal
+addElim = HR.Ann Usage.Omega (HR.Prim AddI) addTyT 0
 
 lamTerm :: HR.Term PrimTy PrimVal
-lamTerm = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.App (HR.App (HR.Prim AddI) (HR.Elim (HR.Var "x"))) (HR.Elim (HR.Var "y")))))
+lamTerm = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.App (HR.App addElim (HR.Elim (HR.Var "x"))) (HR.Elim (HR.Var "y")))))
 
 appLam2 :: HR.Term PrimTy PrimVal
-appLam2 = HR.Elim (HR.App (HR.App (HR.Ann (Usage.SNat 1) lamTerm2 lamTy2 0) (HR.Elim (HR.Prim (Constant (M.ValueInt 2))))) (HR.Elim (HR.Prim (Constant (M.ValueInt 3)))))
+appLam2 = HR.Elim (HR.App (HR.App (HR.Ann (Usage.SNat 1) lamTerm2 lamTy2 0) (HR.Prim (Constant (M.ValueInt 2)))) (HR.Prim (Constant (M.ValueInt 3))))
 
 lamTerm2 :: HR.Term PrimTy PrimVal
-lamTerm2 = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.App (HR.App (HR.Prim AddI) (HR.Elim (HR.Var "x"))) (HR.Elim (HR.Prim (Constant (M.ValueInt 10)))))))
+lamTerm2 = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.App (HR.App addElim (HR.Elim (HR.Var "x"))) (HR.Prim (Constant (M.ValueInt 10))))))
 
 lamTy :: HR.Term PrimTy PrimVal
 lamTy = HR.Pi (Usage.SNat 1) "x" intTy (HR.Pi (Usage.SNat 1) "y" intTy intTy)

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -5,7 +5,6 @@ import Juvix.Backends.Michelson.Compilation.Types
 import Juvix.Backends.Michelson.Parameterisation
 import qualified Juvix.Core.HR as HR
 import qualified Juvix.Core.IR as IR
-import qualified Juvix.Core.IR.Typechecker as Typed
 import qualified Juvix.Core.Pipeline as P
 import qualified Juvix.Core.Types as Core
 import qualified Juvix.Core.Usage as Usage
@@ -69,7 +68,7 @@ exec (EnvE env) param globals = do
 
 type AnnTuple = (HR.Term PrimTy PrimVal, Usage.T, HR.Term PrimTy PrimVal)
 
-type Globals = Typed.Globals PrimTy PrimVal
+type Globals = IR.Globals PrimTy PrimVal
 
 shouldCompileTo ::
   String ->
@@ -97,7 +96,7 @@ toMichelson ::
   HR.Term PrimTy PrimVal ->
   Usage.T ->
   HR.Term PrimTy PrimVal ->
-  Typed.Globals PrimTy PrimVal ->
+  IR.Globals PrimTy PrimVal ->
   IO (Either String EmptyInstr)
 toMichelson term usage ty globals = do
   (res, _) <- exec (P.coreToMichelson term usage ty) michelson globals
@@ -112,7 +111,7 @@ toMichelsonContract ::
   HR.Term PrimTy PrimVal ->
   Usage.T ->
   HR.Term PrimTy PrimVal ->
-  Typed.Globals PrimTy PrimVal ->
+  IR.Globals PrimTy PrimVal ->
   IO (Either String Text)
 toMichelsonContract term usage ty globals = do
   (res, _) <- exec (P.coreToMichelsonContract term usage ty) michelson globals
@@ -135,7 +134,7 @@ test_constant :: T.TestTree
 test_constant =
   shouldCompileTo
     "constant"
-    (twoTerm, Usage.Omega, intTy)
+    (int 2, Usage.Omega, intTy)
     emptyGlobals
     (EmptyInstr (MT.Seq (MT.Nested (MT.PUSH (MT.VInt 2))) MT.Nop))
 
@@ -163,46 +162,76 @@ test_partial_erase =
     emptyGlobals
     (EmptyInstr (MT.Seq (MT.Nested (MT.PUSH (MT.VInt 12))) MT.Nop))
 
-twoTerm :: HR.Term PrimTy PrimVal
-twoTerm = HR.Prim (Constant (M.ValueInt 2))
-
 erasedLamTerm :: HR.Term PrimTy PrimVal
-erasedLamTerm = HR.Lam "x" (HR.Prim (Constant (M.ValueInt 2)))
+erasedLamTerm = HR.Lam "x" $ int 2
 
 erasedLamTy :: HR.Term PrimTy PrimVal
-erasedLamTy = HR.Pi (Usage.SNat 0) "x" intTy intTy
+erasedLamTy = HR.Pi zero "x" intTy intTy
 
 appLam :: HR.Term PrimTy PrimVal
-appLam = HR.Elim (HR.App (HR.App (HR.Ann (Usage.SNat 1) lamTerm lamTy 0) (HR.Prim (Constant (M.ValueInt 2)))) (HR.Prim (Constant (M.ValueInt 3))))
+appLam = HR.Elim $ lamElim `HR.App` int 2 `HR.App` int 3
 
 addTyT :: HR.Term PrimTy PrimVal
-addTyT = HR.Pi one "x" int $ HR.Pi one "y" int $ int where
-  one = Usage.SNat 1
-  int = HR.PrimTy $ PrimTy $ M.Type M.TInt M.noAnn
+addTyT = HR.Pi one "x" intTy $ HR.Pi one "y" intTy intTy
 
 addElim :: HR.Elim PrimTy PrimVal
 addElim = HR.Ann Usage.Omega (HR.Prim AddI) addTyT 0
 
 lamTerm :: HR.Term PrimTy PrimVal
-lamTerm = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.App (HR.App addElim (HR.Elim (HR.Var "x"))) (HR.Elim (HR.Var "y")))))
+lamTerm =
+  HR.Lam "x" $
+  HR.Lam "y" $
+  HR.Elim $ addElim `HR.App` varT "x" `HR.App` varT "y"
+
+lamElim :: HR.Elim PrimTy PrimVal
+lamElim = HR.Ann one lamTerm lamTy 0
 
 appLam2 :: HR.Term PrimTy PrimVal
-appLam2 = HR.Elim (HR.App (HR.App (HR.Ann (Usage.SNat 1) lamTerm2 lamTy2 0) (HR.Prim (Constant (M.ValueInt 2)))) (HR.Prim (Constant (M.ValueInt 3))))
+appLam2 = HR.Elim $ lamElim2 `HR.App` int 2 `HR.App` int 3
 
 lamTerm2 :: HR.Term PrimTy PrimVal
-lamTerm2 = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.App (HR.App addElim (HR.Elim (HR.Var "x"))) (HR.Prim (Constant (M.ValueInt 10))))))
+lamTerm2 =
+  HR.Lam "x" $
+  HR.Lam "y" $
+  HR.Elim $ addElim `HR.App` varT "x" `HR.App` int 10
+
+varT :: Symbol -> HR.Term PrimTy PrimVal
+varT = HR.Elim . HR.Var
 
 lamTy :: HR.Term PrimTy PrimVal
-lamTy = HR.Pi (Usage.SNat 1) "x" intTy (HR.Pi (Usage.SNat 1) "y" intTy intTy)
+lamTy = intTy ~~> intTy ~~> intTy
 
 lamTy2 :: HR.Term PrimTy PrimVal
-lamTy2 = HR.Pi (Usage.SNat 1) "x" intTy (HR.Pi (Usage.SNat 0) "y" intTy intTy)
+lamTy2 = intTy ~~> intTy ~@> intTy
 
-emptyGlobals :: Typed.Globals PrimTy PrimVal
+lamElim2 :: HR.Elim PrimTy PrimVal
+lamElim2 = HR.Ann one lamTerm2 lamTy2 0
+
+emptyGlobals :: IR.Globals PrimTy PrimVal
 emptyGlobals = mempty
 
-intTy :: HR.Term PrimTy PrimVal
-intTy = HR.PrimTy int
+michelsonTy :: M.T -> HR.Term PrimTy PrimVal
+michelsonTy t = HR.PrimTy $ PrimTy $ M.Type t M.noAnn
 
-int :: PrimTy
-int = PrimTy (M.Type M.TInt "")
+intTy :: HR.Term PrimTy PrimVal
+intTy = michelsonTy M.TInt
+
+int :: Integer -> HR.Term PrimTy PrimVal
+int = HR.Prim . Constant . M.ValueInt
+
+intE :: Integer -> HR.Elim PrimTy PrimVal
+intE x = HR.Ann Usage.Omega (int x) intTy 0
+
+arr :: Usage.T -> HR.Term PrimTy PrimVal -> HR.Term PrimTy PrimVal
+    -> HR.Term PrimTy PrimVal
+arr π s t = HR.Pi π "" s (IR.weak t)
+
+infixr 0 ~~>
+(~~>) :: HR.Term PrimTy PrimVal -> HR.Term PrimTy PrimVal
+     -> HR.Term PrimTy PrimVal
+(~~>) = arr one
+
+infixr 0 ~@>
+(~@>) :: HR.Term PrimTy PrimVal -> HR.Term PrimTy PrimVal
+     -> HR.Term PrimTy PrimVal
+(~@>) = arr zero


### PR DESCRIPTION
fixes #326

other notes:

- Since prims are terms now, `*` as multiplication clashes with `*` as type-of-types, so the nat operations have been renamed to `add`, `sub`, `mul`
- For the same reason, `()` clashes with brackets for grouping, so it has been renamed to `tt`
- I think the `builtin__` fields have all the information necessary to remove the `reserved__` and `parse__` fields? If so that should probably happen at some point in the future (edit: no, not quite, because that's where e.g. numeric literals are parsed too)
- Like I mentioned, the builtins in the arithmetic circuit and michelson parameterisations are empty because I don't know them well enough