### PR TITLE
Translating over the tests to a better format

### DIFF
--- a/doc/Code/Test.org
+++ b/doc/Code/Test.org
@@ -155,7 +155,6 @@ Tests that weak works as expected
   + [[Parser]]
   + [[FrontendDesugar]]
   + [[Types]]
-  + [[Types]]
   + [[Library]]
 ** Golden
 - _Relies on_

--- a/doc/Code/Test.org
+++ b/doc/Code/Test.org
@@ -153,7 +153,6 @@ Tests that weak works as expected
 - _Relies on_
   + [[NameSymbol]]
   + [[Parser]]
-  + [[Base]]
   + [[FrontendDesugar]]
   + [[Types]]
   + [[Types]]

--- a/doc/Code/Test.org
+++ b/doc/Code/Test.org
@@ -151,9 +151,11 @@ Tests that weak works as expected
 * Frontend
 ** Desugar
 - _Relies on_
+  + [[NameSymbol]]
   + [[Parser]]
   + [[Base]]
   + [[FrontendDesugar]]
+  + [[Types]]
   + [[Types]]
   + [[Library]]
 ** Golden
@@ -167,7 +169,6 @@ Tests that weak works as expected
   + [[Parser]]
   + [[Types]]
   + [[Types]]
-  + [[Base]]
   + [[Library]]
 * FrontendContextualise
 ** Infix

--- a/doc/Code/Test.org
+++ b/doc/Code/Test.org
@@ -147,6 +147,7 @@ Tests that weak works as expected
   + [[Evaluator]]
   + [[Types]]
   + [[Library]]
+* Files
 * Frontend
 ** Desugar
 - _Relies on_
@@ -162,7 +163,9 @@ Tests that weak works as expected
   + [[Library]]
 ** Parser <<Frontend/Parser>>
 - _Relies on_
+  + [[NameSymbol]]
   + [[Parser]]
+  + [[Types]]
   + [[Types]]
   + [[Base]]
   + [[Library]]

--- a/src/Juvix/FrontendContextualise/InfixPrecedence/ShuntYard.hs
+++ b/src/Juvix/FrontendContextualise/InfixPrecedence/ShuntYard.hs
@@ -18,7 +18,7 @@ data Precedence sym = Pred sym Associativity Int
 data Error sym
   = Clash (Precedence sym) (Precedence sym)
   | MoreEles
-  deriving (Show)
+  deriving (Show, Eq)
 
 -- Not a real ordering, hence not an ord instance
 predOrd :: Precedence sym -> Precedence sym -> Either (Error sym) Bool

--- a/src/Juvix/FrontendDesugar/RemoveCond/Transform.hs
+++ b/src/Juvix/FrontendDesugar/RemoveCond/Transform.hs
@@ -8,7 +8,7 @@ import Juvix.Library
 -- The actual transform we are doing
 transformCond :: Old.Cond Old.Expression -> New.Expression
 transformCond (Old.C xs) =
-  foldr f (fList last []) xs
+  foldr f (fList last []) (NonEmpty.init xs)
   where
     fList (Old.CondExpression pred body) falses =
       boolean "True" (transformExpression body)

--- a/test/Frontend/Desugar.hs
+++ b/test/Frontend/Desugar.hs
@@ -5,7 +5,6 @@ import qualified Juvix.Core.Common.NameSymbol as NameSym
 import qualified Juvix.Frontend.Parser as Parser
 import qualified Juvix.FrontendDesugar as Desugar
 import qualified Juvix.FrontendDesugar.RemoveDo.Types as AST
-import qualified Juvix.FrontendDesugar.RemoveDo.Types as Desugared
 import Juvix.Library
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
@@ -16,7 +15,7 @@ allDesugar =
     "desugar Tests"
     [guardTest]
 
-shouldDesugar :: T.TestName -> ByteString -> [Desugared.TopLevel] -> T.TestTree
+shouldDesugar :: T.TestName -> ByteString -> [AST.TopLevel] -> T.TestTree
 shouldDesugar name x y =
   T.testGroup
     "Desugar tests"

--- a/test/Frontend/Desugar.hs
+++ b/test/Frontend/Desugar.hs
@@ -1,10 +1,9 @@
 module Frontend.Desugar where
 
-import Data.Attoparsec.ByteString (parseOnly)
+import qualified Data.Attoparsec.ByteString as Parsec
 import qualified Juvix.Core.Common.NameSymbol as NameSym
 import qualified Juvix.Frontend.Parser as Parser
-import Juvix.Frontend.Types.Base
-import Juvix.FrontendDesugar (desugar)
+import qualified Juvix.FrontendDesugar as Desugar
 import qualified Juvix.FrontendDesugar.RemoveDo.Types as AST
 import qualified Juvix.FrontendDesugar.RemoveDo.Types as Desugared
 import Juvix.Library
@@ -17,14 +16,15 @@ allDesugar =
     "desugar Tests"
     [guardTest]
 
-shouldDesugar ::
-  T.TestName -> ByteString -> [Desugared.TopLevel] -> T.TestTree
+shouldDesugar :: T.TestName -> ByteString -> [Desugared.TopLevel] -> T.TestTree
 shouldDesugar name x y =
   T.testGroup
     "Desugar tests"
     [ T.testCase
         ("desugar: " <> name <> " " <> show x <> " should desugar to " <> show y)
-        (fmap desugar (parseOnly (many Parser.topLevelSN) x) T.@=? Right y)
+        ( fmap Desugar.f (Parsec.parseOnly (many Parser.topLevelSN) x)
+            T.@=? Right y
+        )
     ]
 
 guardTest :: T.TestTree

--- a/test/Frontend/Desugar.hs
+++ b/test/Frontend/Desugar.hs
@@ -1,20 +1,13 @@
 module Frontend.Desugar where
 
 import Data.Attoparsec.ByteString (parseOnly)
+import qualified Juvix.Core.Common.NameSymbol as NameSym
 import qualified Juvix.Frontend.Parser as Parser
 import Juvix.Frontend.Types.Base
 import Juvix.FrontendDesugar (desugar)
+import qualified Juvix.FrontendDesugar.RemoveDo.Types as AST
 import qualified Juvix.FrontendDesugar.RemoveDo.Types as Desugared
 import Juvix.Library
-  ( (<>),
-    ByteString,
-    Either (Right),
-    Maybe (..),
-    NonEmpty (..),
-    fmap,
-    many,
-    show,
-  )
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
 
@@ -39,63 +32,37 @@ guardTest =
   shouldDesugar
     "guardTest"
     "let foo | x == 3 = 3 | else = 2"
-    [ Function'
-        ( FunctionX
-            ( "foo",
-              FunctionLikeX
-                { extFunctionLike =
-                    ( [],
-                      Match'
-                        ( Match'''
-                            { matchOn =
-                                Infix'
-                                  ( Inf'
-                                      { infixLeft = Name' ("x" :| []) (),
-                                        infixOp = "==" :| [],
-                                        infixRight = Constant' (Number' (Integer'' 3 ()) ()) (),
-                                        annInf = ()
-                                      }
-                                  )
-                                  (),
-                              matchBindigns =
-                                MatchL'
-                                  { matchLPattern =
-                                      MatchLogic'
-                                        { matchLogicContents = MatchCon' ("True" :| []) [] (),
-                                          matchLogicNamed = Nothing,
-                                          annMatchLogic = ()
-                                        },
-                                    matchLBody = Constant' (Number' (Integer'' 3 ()) ()) (),
-                                    annMatchL = ()
-                                  }
-                                  :| [ MatchL'
-                                         { matchLPattern =
-                                             MatchLogic'
-                                               { matchLogicContents = MatchCon' ("False" :| []) [] (),
-                                                 matchLogicNamed = Nothing,
-                                                 annMatchLogic = ()
-                                               },
-                                           matchLBody =
-                                             Match'
-                                               ( Match'''
-                                                   { matchOn = Name' ("else" :| []) (),
-                                                     matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("True" :| []) [] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Constant' (Number' (Integer'' 2 ()) ()) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("False" :| []) [] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Match' (Match''' {matchOn = Name' ("else" :| []) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("True" :| []) [] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Constant' (Number' (Integer'' 2 ()) ()) (), annMatchL = ()} :| [], annMatch'' = ()}) (), annMatchL = ()}],
-                                                     annMatch'' = ()
-                                                   }
-                                               )
-                                               (),
-                                           annMatchL = ()
-                                         }
-                                     ],
-                              annMatch'' = ()
-                            }
-                        )
-                        ()
-                    )
-                }
-                :| [],
-              Nothing
-            )
-        )
-        ()
+    [ ( AST.MatchL
+          { matchLPattern =
+              AST.MatchCon (NameSym.fromSymbol "True") []
+                |> flip AST.MatchLogic Nothing,
+            matchLBody =
+              AST.Constant (AST.Number (AST.Integer' 3))
+          }
+          :| [ ( AST.MatchL
+                   { matchLPattern =
+                       AST.MatchCon (NameSym.fromSymbol "True") []
+                         |> flip AST.MatchLogic Nothing,
+                     matchLBody =
+                       AST.Constant (AST.Number (AST.Integer' 2))
+                   }
+                   :| []
+               )
+                 |> AST.Match'' (AST.Name (NameSym.fromSymbol "else"))
+                 |> AST.Match
+                 |> AST.MatchL
+                   (AST.MatchLogic (AST.MatchCon (NameSym.fromSymbol "False") []) Nothing)
+             ]
+      )
+        |> AST.Match''
+          ( AST.Integer' 3
+              |> AST.Number
+              |> AST.Constant
+              |> AST.Inf (AST.Name (NameSym.fromSymbol "x")) (NameSym.fromSymbol "==")
+              |> AST.Infix
+          )
+        |> AST.Match
+        |> AST.Like []
+        |> (\x -> AST.Func "foo" (pure x) Nothing)
+        |> AST.Function
     ]

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -766,37 +766,42 @@ moduleOpen =
         <> "  let bah t = Int.(t + 3) \n"
         <> "end"
     )
-    [ Module'
-        ( Mod'
-            ( Like'
-                { functionLikedName = Sym "Foo",
-                  functionLikeArgs =
-                    [ ConcreteA'
-                        ( MatchLogic'
-                            { matchLogicContents = MatchCon' (Sym "Int" :| []) [] (),
-                              matchLogicNamed = Nothing,
-                              annMatchLogic = ()
-                            }
-                        )
-                        ()
-                    ],
-                  functionLikeBody =
-                    Body'
-                      ( Function'
-                          ( Func'
-                              (Like' {functionLikedName = Sym "T", functionLikeArgs = [], functionLikeBody = Body' (Name' (Sym "Int" :| [Sym "t"]) ()) (), annLike = ()})
-                              ()
-                          )
-                          ()
-                          :| [Signature' (Sig' {signatureName = Sym "bah", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' (Sym "T" :| []) (), infixOp = Sym "->" :| [], infixRight = Name' (Sym "T" :| []) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (), Function' (Func' (Like' {functionLikedName = Sym "bah", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' (Sym "t") (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (OpenExpr' (OpenExpress' {moduleOpenExprModuleN = Sym "Int" :| [], moduleOpenExprExpr = Infix' (Inf' {infixLeft = Name' (Sym "t" :| []) (), infixOp = Sym "+" :| [], infixRight = Constant' (Number' (Integer'' 3 ()) ()) (), annInf = ()}) (), annOpenExpress = ()}) ()) (), annLike = ()}) ()) ()]
-                      )
-                      (),
-                  annLike = ()
-                }
-            )
-            ()
-        )
-        ()
+    [ ( AST.Name (NameSymbol.fromSymbol "Int.t")
+          |> AST.Body
+          |> AST.Like "T" []
+          |> AST.Func
+          |> AST.Function
+      )
+        :| [ AST.Inf
+               (AST.Name (NameSymbol.fromSymbol "T"))
+               (NameSymbol.fromSymbol "->")
+               (AST.Name (NameSymbol.fromSymbol "T"))
+               |> AST.Infix
+               |> flip (AST.Sig "bah" Nothing) []
+               |> AST.Signature,
+             --
+             AST.Inf
+               (AST.Name (NameSymbol.fromSymbol "t"))
+               (NameSymbol.fromSymbol "+")
+               (AST.Constant (AST.Number (AST.Integer' 3)))
+               |> AST.Infix
+               |> AST.OpenExpress (NameSymbol.fromSymbol "Int")
+               |> AST.OpenExpr
+               |> AST.Body
+               |> AST.Like
+                 "bah"
+                 [AST.ConcreteA (AST.MatchLogic (AST.MatchName "t") Nothing)]
+               |> AST.Func
+               |> AST.Function
+           ]
+        |> AST.Body
+        |> AST.Like
+          "Foo"
+          [ AST.MatchLogic (AST.MatchCon (NameSymbol.fromSymbol "Int") []) Nothing
+              |> AST.ConcreteA
+          ]
+        |> AST.Mod
+        |> AST.Module
     ]
 
 moduleOpen' :: T.TestTree
@@ -879,12 +884,12 @@ typeNameNoUniverse =
 
 simpleNamedCon :: T.TestTree
 simpleNamedCon =
-  [ AST.MatchLogic (AST.MatchName (intern "a")) Nothing,
-    AST.MatchLogic (AST.MatchName (intern "b")) Nothing,
-    AST.MatchLogic (AST.MatchName (intern "c")) Nothing
+  [ AST.MatchLogic (AST.MatchName "a") Nothing,
+    AST.MatchLogic (AST.MatchName "b") Nothing,
+    AST.MatchLogic (AST.MatchName "c") Nothing
   ]
     |> AST.MatchCon (NameSymbol.fromSymbol "Hi")
-    |> flip AST.MatchLogic (Just (intern "foo"))
+    |> flip AST.MatchLogic (Just "foo")
     |> shouldParseAs
       "simpleNamedCon"
       (parse Parser.matchLogic)
@@ -893,18 +898,18 @@ simpleNamedCon =
 matchMoreComplex :: T.TestTree
 matchMoreComplex =
   [ Nothing
-      |> AST.MatchLogic (AST.MatchName (intern "nah"))
-      |> AST.NonPunned (intern "a" :| [])
-      |> (:| [AST.Punned (intern "f" :| [])])
+      |> AST.MatchLogic (AST.MatchName "nah")
+      |> AST.NonPunned (NameSymbol.fromSymbol "a")
+      |> (:| [AST.Punned (NameSymbol.fromSymbol "f")])
       |> AST.MatchRecord
-      |> flip AST.MatchLogic (Just (intern "nah")),
+      |> flip AST.MatchLogic (Just "nah"),
     --
-    AST.MatchLogic (AST.MatchName (intern "b")) Nothing,
+    AST.MatchLogic (AST.MatchName "b") Nothing,
     --
     AST.MatchLogic (AST.MatchConst (AST.Number (AST.Integer' 5))) Nothing
   ]
-    |> AST.MatchCon (intern "Hi" :| [])
-    |> flip AST.MatchLogic (Just (intern "foo"))
+    |> AST.MatchCon (NameSymbol.fromSymbol "Hi")
+    |> flip AST.MatchLogic (Just "foo")
     |> shouldParseAs
       "matchMoreComplex"
       (parse Parser.matchLogic)

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -338,52 +338,22 @@ fun1 =
     "fun1"
     Parser.parse
     "let f foo@(A b c d) = 3"
-    [ Function'
-        ( Func'
-            ( Like'
-                { functionLikedName = Sym "f",
-                  functionLikeArgs =
-                    [ ConcreteA'
-                        ( MatchLogic'
-                            { matchLogicContents =
-                                MatchCon'
-                                  (Sym "A" :| [])
-                                  [ MatchLogic'
-                                      { matchLogicContents = MatchName' (Sym "b") (),
-                                        matchLogicNamed = Nothing,
-                                        annMatchLogic = ()
-                                      },
-                                    MatchLogic'
-                                      { matchLogicContents = MatchName' (Sym "c") (),
-                                        matchLogicNamed = Nothing,
-                                        annMatchLogic = ()
-                                      },
-                                    MatchLogic'
-                                      { matchLogicContents = MatchName' (Sym "d") (),
-                                        matchLogicNamed = Nothing,
-                                        annMatchLogic = ()
-                                      }
-                                  ]
-                                  (),
-                              matchLogicNamed = Just (Sym "foo"),
-                              annMatchLogic = ()
-                            }
-                        )
-                        ()
-                    ],
-                  functionLikeBody =
-                    Body'
-                      ( Constant'
-                          (Number' (Integer'' 3 ()) ())
-                          ()
-                      )
-                      (),
-                  annLike = ()
-                }
-            )
-            ()
-        )
-        ()
+    [ AST.Integer' 3
+        |> AST.Number
+        |> AST.Constant
+        |> AST.Body
+        |> AST.Like
+          "f"
+          [ [ AST.MatchLogic (AST.MatchName "b") Nothing,
+              AST.MatchLogic (AST.MatchName "c") Nothing,
+              AST.MatchLogic (AST.MatchName "d") Nothing
+            ]
+              |> AST.MatchCon (NameSymbol.fromSymbol "A")
+              |> flip AST.MatchLogic (Just "foo")
+              |> AST.ConcreteA
+          ]
+        |> AST.Func
+        |> AST.Function
     ]
 
 fun2 :: T.TestTree

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -122,7 +122,6 @@ many1FunctionsParser =
         <> "          print failed; \n"
         <> "          fail"
     )
-    -- to avoid having too many lines some of these lines go over 80
     [ Function'
         ( Func'
             ( Like'
@@ -393,44 +392,23 @@ fun2 =
     "fun2"
     Parser.parse
     "let f foo | foo = 2 | else = 3"
-    [ Function'
-        ( Func'
-            ( Like'
-                { functionLikedName = Sym "f",
-                  functionLikeArgs =
-                    [ ConcreteA'
-                        ( MatchLogic'
-                            { matchLogicContents = MatchName' (Sym "foo") (),
-                              matchLogicNamed = Nothing,
-                              annMatchLogic = ()
-                            }
-                        )
-                        ()
-                    ],
-                  functionLikeBody =
-                    Guard'
-                      ( C'
-                          ( CondExpression'
-                              { condLogicPred = Name' (Sym "foo" :| []) (),
-                                condLogicBody = Constant' (Number' (Integer'' 2 ()) ()) (),
-                                annCondExpression = ()
-                              }
-                              :| [ CondExpression'
-                                     { condLogicPred = Name' (Sym "else" :| []) (),
-                                       condLogicBody = Constant' (Number' (Integer'' 3 ()) ()) (),
-                                       annCondExpression = ()
-                                     }
-                                 ]
-                          )
-                          ()
-                      )
-                      (),
-                  annLike = ()
-                }
-            )
-            ()
-        )
-        ()
+    [ ( AST.Integer' 2
+          |> AST.Number
+          |> AST.Constant
+          |> AST.CondExpression (AST.Name (NameSymbol.fromSymbol "foo"))
+      )
+        :| [ AST.Integer' 3
+               |> AST.Number
+               |> AST.Constant
+               |> AST.CondExpression (AST.Name (NameSymbol.fromSymbol "else"))
+           ]
+        |> AST.C
+        |> AST.Guard
+        |> AST.Like
+          "f"
+          [AST.ConcreteA (AST.MatchLogic (AST.MatchName "foo") Nothing)]
+        |> AST.Func
+        |> AST.Function
     ]
 
 --------------------------------------------------------------------------------

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -632,12 +632,12 @@ matchMoreComplex =
 condTest1 :: T.TestTree
 condTest1 =
   AST.CondExpression
-    { condLogicPred = AST.Name (intern "foo" :| []),
-      condLogicBody = AST.Name (intern "a" :| [])
+    { condLogicPred = AST.Name (NameSym.fromSymbol "foo"),
+      condLogicBody = AST.Name (NameSym.fromSymbol "a")
     }
     :| [ AST.CondExpression
-           { condLogicPred = AST.Name (intern "else" :| []),
-             condLogicBody = AST.Name (intern "b" :| [])
+           { condLogicPred = AST.Name (NameSym.fromSymbol "else"),
+             condLogicBody = AST.Name (NameSym.fromSymbol "b")
            }
        ]
     |> AST.C
@@ -655,14 +655,14 @@ condTest1 =
 
 record1 :: T.TestTree
 record1 =
-  AST.Punned (intern "a" :| [])
+  AST.Punned (NameSym.fromSymbol "a")
     :| [ AST.Inf
            { infixLeft = AST.Constant (AST.Number (AST.Integer' 3)),
-             infixOp = intern "+" :| [],
+             infixOp = NameSym.fromSymbol "+",
              infixRight = AST.Constant (AST.Number (AST.Integer' 5))
            }
            |> AST.Infix
-           |> AST.NonPunned (intern "b" :| [])
+           |> AST.NonPunned (NameSym.fromSymbol "b")
        ]
     |> AST.ExpressionRecord
     |> AST.ExpRecord
@@ -677,14 +677,15 @@ record1 =
 
 parens1 :: T.TestTree
 parens1 =
-  AST.Punned (intern "a" :| [])
-    :| [ AST.Inf
-           { infixLeft = AST.Constant (AST.Number (AST.Integer' 3)),
-             infixOp = intern "+" :| [],
-             infixRight = AST.Constant (AST.Number (AST.Integer' 5))
-           }
+  AST.Punned (NameSym.fromSymbol "a")
+    :| [ AST.Integer' 5
+           |> AST.Number
+           |> AST.Constant
+           |> AST.Inf
+             (AST.Constant (AST.Number (AST.Integer' 3)))
+             (NameSym.fromSymbol "+")
            |> AST.Infix
-           |> AST.NonPunned (intern "b" :| [])
+           |> AST.NonPunned (NameSym.fromSymbol "b")
        ]
     |> AST.ExpressionRecord
     |> AST.ExpRecord

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -108,7 +108,8 @@ many1FunctionsParser =
   shouldParseAs
     "many1FunctionsParser"
     (parse $ many Parser.topLevelSN)
-    ( "let foo a b c = (+) (a + b) c\n"
+    ( ""
+        <> "let foo a b c = (+) (a + b) c\n"
         <> "let bah = foo 1 2 3\n"
         <> "let nah \n"
         <> "  | bah == 5 = 7 \n"
@@ -122,103 +123,101 @@ many1FunctionsParser =
         <> "          print failed; \n"
         <> "          fail"
     )
-    [ Function'
-        ( Func'
-            ( Like'
-                { functionLikedName = "foo",
-                  functionLikeArgs =
-                    [ ConcreteA'
-                        ( MatchLogic'
-                            { matchLogicContents = MatchName' "a" (),
-                              matchLogicNamed = Nothing,
-                              annMatchLogic = ()
-                            }
-                        )
-                        (),
-                      ConcreteA'
-                        ( MatchLogic'
-                            { matchLogicContents = MatchName' "b" (),
-                              matchLogicNamed = Nothing,
-                              annMatchLogic = ()
-                            }
-                        )
-                        (),
-                      ConcreteA'
-                        ( MatchLogic'
-                            { matchLogicContents = MatchName' "c" (),
-                              matchLogicNamed = Nothing,
-                              annMatchLogic = ()
-                            }
-                        )
-                        ()
-                    ],
-                  functionLikeBody =
-                    Body'
-                      ( Application'
-                          ( App'
-                              { applicationName = Name' ("+" :| []) (),
-                                applicationArgs =
-                                  Parened'
-                                    ( Infix'
-                                        ( Inf'
-                                            { infixLeft = Name' ("a" :| []) (),
-                                              infixOp = "+" :| [],
-                                              infixRight = Name' ("b" :| []) (),
-                                              annInf = ()
-                                            }
-                                        )
-                                        ()
-                                    )
-                                    ()
-                                    :| [Name' ("c" :| []) ()],
-                                annApp = ()
-                              }
-                          )
-                          ()
-                      )
-                      (),
-                  annLike = ()
+    [ ( AST.Inf
+          (AST.Name (NameSym.fromSymbol "a"))
+          (NameSym.fromSymbol "+")
+          (AST.Name (NameSym.fromSymbol "b"))
+          |> AST.Infix
+          |> AST.Parened
+      )
+        :| [AST.Name (NameSym.fromSymbol "c")]
+        |> AST.App
+          (AST.Name (NameSym.fromSymbol "+"))
+        |> AST.Application
+        |> AST.Body
+        |> AST.Like
+          "foo"
+          [ AST.ConcreteA (AST.MatchLogic (AST.MatchName "a") Nothing),
+            AST.ConcreteA (AST.MatchLogic (AST.MatchName "b") Nothing),
+            AST.ConcreteA (AST.MatchLogic (AST.MatchName "c") Nothing)
+          ]
+        |> AST.Func
+        |> AST.Function,
+      --
+      ( AST.Constant (AST.Number (AST.Integer' 1))
+          :| [ AST.Constant (AST.Number (AST.Integer' 2)),
+               AST.Constant (AST.Number (AST.Integer' 3))
+             ]
+      )
+        |> AST.App
+          (AST.Name (NameSym.fromSymbol "foo"))
+        |> AST.Application
+        |> AST.Body
+        |> AST.Like "bah" []
+        |> AST.Func
+        |> AST.Function,
+      --
+      ( AST.CondExpression
+          { condLogicPred =
+              AST.Integer' 5
+                |> AST.Number
+                |> AST.Constant
+                |> AST.Inf (AST.Name (NameSym.fromSymbol "bah")) (NameSym.fromSymbol "==")
+                |> AST.Infix,
+            condLogicBody =
+              AST.Constant (AST.Number (AST.Integer' 7))
+          }
+          :| [ AST.Integer' 11
+                 |> AST.Number
+                 |> AST.Constant
+                 |> AST.CondExpression (AST.Name (NameSym.fromSymbol "else"))
+             ]
+      )
+        |> AST.C
+        |> AST.Guard
+        |> AST.Like "nah" []
+        |> AST.Func
+        |> AST.Function,
+      --
+
+      AST.Let''
+        { letBindings =
+            AST.Name (NameSym.fromSymbol "nah")
+              |> AST.Body
+              |> AST.Like "check" [],
+          letBody =
+            ( AST.MatchL
+                { matchLPattern =
+                    AST.MatchLogic (AST.MatchName "seven") Nothing,
+                  matchLBody =
+                    AST.Constant (AST.Number (AST.Integer' 11))
                 }
+                :| [ AST.Integer' 7
+                       |> AST.Number
+                       |> AST.Constant
+                       |> AST.MatchL (AST.MatchLogic (AST.MatchName "eleven") Nothing),
+                     --
+
+                     (AST.Name (NameSym.fromSymbol "failed") :| [])
+                       |> AST.App (AST.Name (NameSym.fromSymbol "print"))
+                       |> AST.Application
+                       |> AST.DoBody Nothing
+                       |> (:| [AST.DoBody Nothing (AST.Name (NameSym.fromSymbol "fail"))])
+                       |> AST.Do''
+                       |> AST.Do
+                       |> AST.OpenExpress (NameSym.fromSymbol "Fails")
+                       |> AST.OpenExpr
+                       |> AST.MatchL (AST.MatchLogic (AST.MatchName "f") Nothing)
+                   ]
             )
-            ()
-        )
-        (),
-      Function'
-        ( Func'
-            ( Like'
-                { functionLikedName = "bah",
-                  functionLikeArgs = [],
-                  functionLikeBody = Body' (Application' (App' {applicationName = Name' ("foo" :| []) (), applicationArgs = Constant' (Number' (Integer'' 1 ()) ()) () :| [Constant' (Number' (Integer'' 2 ()) ()) (), Constant' (Number' (Integer'' 3 ()) ()) ()], annApp = ()}) ()) (),
-                  annLike = ()
-                }
-            )
-            ()
-        )
-        (),
-      Function'
-        ( Func'
-            ( Like'
-                { functionLikedName = "nah",
-                  functionLikeArgs = [],
-                  functionLikeBody = Guard' (C' (CondExpression' {condLogicPred = Infix' (Inf' {infixLeft = Name' ("bah" :| []) (), infixOp = "==" :| [], infixRight = Constant' (Number' (Integer'' 5 ()) ()) (), annInf = ()}) (), condLogicBody = Constant' (Number' (Integer'' 7 ()) ()) (), annCondExpression = ()} :| [CondExpression' {condLogicPred = Name' ("else" :| []) (), condLogicBody = Constant' (Number' (Integer'' 11 ()) ()) (), annCondExpression = ()}]) ()) (),
-                  annLike = ()
-                }
-            )
-            ()
-        )
-        (),
-      Function'
-        ( Func'
-            ( Like'
-                { functionLikedName = "test",
-                  functionLikeArgs = [],
-                  functionLikeBody = Body' (Let' (Let''' {letBindings = Like' {functionLikedName = "check", functionLikeArgs = [], functionLikeBody = Body' (Name' ("nah" :| []) ()) (), annLike = ()}, letBody = Match' (Match''' {matchOn = Name' ("check" :| []) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchName' "seven" (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Constant' (Number' (Integer'' 11 ()) ()) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchName' "eleven" (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Constant' (Number' (Integer'' 7 ()) ()) (), annMatchL = ()}, MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchName' "f" (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = OpenExpr' (OpenExpress' {moduleOpenExprModuleN = "Fails" :| [], moduleOpenExprExpr = Do' (Do''' (DoBody' {doBodyName = Nothing, doBodyExpr = Application' (App' {applicationName = Name' ("print" :| []) (), applicationArgs = Name' ("failed" :| []) () :| [], annApp = ()}) (), annDoBody = ()} :| [DoBody' {doBodyName = Nothing, doBodyExpr = Name' ("fail" :| []) (), annDoBody = ()}]) ()) (), annOpenExpress = ()}) (), annMatchL = ()}], annMatch'' = ()}) (), annLet'' = ()}) ()) (),
-                  annLike = ()
-                }
-            )
-            ()
-        )
-        ()
+              |> AST.Match'' (AST.Name (NameSym.fromSymbol "check"))
+              |> AST.Match
+        }
+        |> AST.Let
+        |> AST.Body
+        |> AST.Like "test" []
+        |> AST.Func
+        |> AST.Function
     ]
 
 --------------------------------------------------------------------------------

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -614,106 +614,46 @@ sumTypeTest =
 
 superArrowCase :: T.TestTree
 superArrowCase =
-  shouldParseAs
-    "superArrowCase"
-    (parse Parser.expression)
-    "( b : Bah ->  c : B -o Foo) -> Foo a b -> a : Bah a c -o ( HAHAHHA -> foo )"
-    ( Infix'
-        ( Inf'
-            { infixLeft =
-                Parened'
-                  ( Infix'
-                      ( Inf'
-                          { infixLeft = Name' (Sym "b" :| []) (),
-                            infixOp = Sym ":" :| [],
-                            infixRight =
-                              Infix'
-                                ( Inf'
-                                    { infixLeft = Name' (Sym "Bah" :| []) (),
-                                      infixOp = Sym "->" :| [],
-                                      infixRight =
-                                        Infix'
-                                          ( Inf'
-                                              { infixLeft = Name' (Sym "c" :| []) (),
-                                                infixOp = Sym ":" :| [],
-                                                infixRight =
-                                                  Infix'
-                                                    ( Inf'
-                                                        { infixLeft = Name' (Sym "B" :| []) (),
-                                                          infixOp = Sym "-o" :| [],
-                                                          infixRight = Name' (Sym "Foo" :| []) (),
-                                                          annInf = ()
-                                                        }
-                                                    )
-                                                    (),
-                                                annInf = ()
-                                              }
-                                          )
-                                          (),
-                                      annInf = ()
-                                    }
-                                )
-                                (),
-                            annInf = ()
-                          }
-                      )
-                      ()
-                  )
-                  (),
-              infixOp = Sym "->" :| [],
-              infixRight =
-                Infix'
-                  ( Inf'
-                      { infixLeft =
-                          Application'
-                            ( App'
-                                { applicationName = Name' (Sym "Foo" :| []) (),
-                                  applicationArgs = Name' (Sym "a" :| []) () :| [Name' (Sym "b" :| []) ()],
-                                  annApp = ()
-                                }
-                            )
-                            (),
-                        infixOp = Sym "->" :| [],
-                        infixRight =
-                          Infix'
-                            ( Inf'
-                                { infixLeft = Name' (Sym "a" :| []) (),
-                                  infixOp = Sym ":" :| [],
-                                  infixRight =
-                                    Infix'
-                                      ( Inf'
-                                          { infixLeft = Application' (App' {applicationName = Name' (Sym "Bah" :| []) (), applicationArgs = Name' (Sym "a" :| []) () :| [Name' (Sym "c" :| []) ()], annApp = ()}) (),
-                                            infixOp = Sym "-o" :| [],
-                                            infixRight =
-                                              Parened'
-                                                ( Infix'
-                                                    ( Inf'
-                                                        { infixLeft = Name' (Sym "HAHAHHA" :| []) (),
-                                                          infixOp = Sym "->" :| [],
-                                                          infixRight = Name' (Sym "foo" :| []) (),
-                                                          annInf = ()
-                                                        }
-                                                    )
-                                                    ()
-                                                )
-                                                (),
-                                            annInf = ()
-                                          }
-                                      )
-                                      (),
-                                  annInf = ()
-                                }
-                            )
-                            (),
-                        annInf = ()
-                      }
-                  )
-                  (),
-              annInf = ()
-            }
-        )
-        ()
-    )
+  AST.Name (NameSymbol.fromSymbol "foo")
+    |> AST.Inf (AST.Name (NameSymbol.fromSymbol "HAHAHHA")) (NameSymbol.fromSymbol "->")
+    |> AST.Infix
+    |> AST.Parened
+    |> AST.Inf
+      ( AST.App
+          (AST.Name (NameSymbol.fromSymbol "Bah"))
+          (AST.Name (NameSymbol.fromSymbol "a") :| [(AST.Name (NameSymbol.fromSymbol "c"))])
+          |> AST.Application
+      )
+      (NameSymbol.fromSymbol "-o")
+    |> AST.Infix
+    |> AST.Inf (AST.Name (NameSymbol.fromSymbol "a")) (NameSymbol.fromSymbol ":")
+    |> AST.Infix
+    |> AST.Inf
+      ( AST.App
+          (AST.Name (NameSymbol.fromSymbol "Foo"))
+          (AST.Name (NameSymbol.fromSymbol "a") :| [(AST.Name (NameSymbol.fromSymbol "b"))])
+          |> AST.Application
+      )
+      (NameSymbol.fromSymbol "->")
+    |> AST.Infix
+    |> AST.Inf
+      ( AST.Name (NameSymbol.fromSymbol "Foo")
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "B")) (NameSymbol.fromSymbol "-o")
+          |> AST.Infix
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "c")) (NameSymbol.fromSymbol ":")
+          |> AST.Infix
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "Bah")) (NameSymbol.fromSymbol "->")
+          |> AST.Infix
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "b")) (NameSymbol.fromSymbol ":")
+          |> AST.Infix
+          |> AST.Parened
+      )
+      (NameSymbol.fromSymbol "->")
+    |> AST.Infix
+    |> shouldParseAs
+      "superArrowCase"
+      (parse Parser.expression)
+      "( b : Bah ->  c : B -o Foo) -> Foo a b -> a : Bah a c -o ( HAHAHHA -> foo )"
 
 --------------------------------------------------
 -- alias tests
@@ -725,29 +665,18 @@ typeTest =
     "typeTest"
     Parser.parse
     "type Foo a b c d = | Foo nah bah sad"
-    [ Type'
-        ( Typ'
-            { typeUsage = Nothing,
-              typeName' = Sym "Foo",
-              typeArgs = [Sym "a", Sym "b", Sym "c", Sym "d"],
-              typeForm =
-                NonArrowed'
-                  { dataAdt =
-                      Sum'
-                        ( S'
-                            { sumConstructor = Sym "Foo",
-                              sumValue = Just (ADTLike' [Name' (Sym "nah" :| []) (), Name' (Sym "bah" :| []) (), Name' (Sym "sad" :| []) ()] ()),
-                              annS = ()
-                            }
-                            :| []
-                        )
-                        (),
-                    annNonArrowed = ()
-                  },
-              annTyp = ()
-            }
-        )
-        ()
+    [ [ AST.Name (NameSymbol.fromSymbol "nah"),
+        AST.Name (NameSymbol.fromSymbol "bah"),
+        AST.Name (NameSymbol.fromSymbol "sad")
+      ]
+        |> AST.ADTLike
+        |> Just
+        |> AST.S "Foo"
+        |> (:| [])
+        |> AST.Sum
+        |> AST.NonArrowed
+        |> AST.Typ Nothing "Foo" ["a", "b", "c", "d"]
+        |> AST.Type
     ]
 
 --------------------------------------------------------------------------------

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -13,7 +13,6 @@ import qualified Juvix.Core.Common.NameSymbol as NameSym
 import qualified Juvix.Frontend.Parser as Parser
 import Juvix.Frontend.Types (Expression, TopLevel)
 import qualified Juvix.Frontend.Types as AST
-import Juvix.Frontend.Types.Base
 import Juvix.Library hiding (show)
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -13,10 +13,10 @@ import qualified Juvix.Core.Common.NameSymbol as NameSym
 import qualified Juvix.Frontend.Parser as Parser
 import Juvix.Frontend.Types (Expression, TopLevel)
 import qualified Juvix.Frontend.Types as AST
-import Juvix.Library hiding (show)
+import Juvix.Library
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
-import Prelude (String, error, show)
+import Prelude (String, error)
 
 allParserTests :: T.TestTree
 allParserTests =

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -451,161 +451,54 @@ sumTypeTest =
         <> "            | C { a : Int, #b : Int } \n"
         <> "            | D { a : Int, #b : Int } : Foo Int (Fooy -> Nada)"
     )
-    [ Type'
-        ( Typ'
-            { typeUsage = Nothing,
-              typeName' = Sym "Foo",
-              typeArgs =
-                [Sym "a", Sym "b", Sym "c"],
-              typeForm =
-                NonArrowed'
-                  { dataAdt =
-                      Sum'
-                        ( S'
-                            { sumConstructor = Sym "A",
-                              sumValue =
-                                Just
-                                  ( Arrow'
-                                      ( Infix'
-                                          ( Inf'
-                                              { infixLeft = Name' (Sym "b" :| []) (),
-                                                infixOp = Sym ":" :| [],
-                                                infixRight =
-                                                  Infix'
-                                                    ( Inf'
-                                                        { infixLeft = Name' (Sym "a" :| []) (),
-                                                          infixOp = Sym "->" :| [],
-                                                          infixRight =
-                                                            Infix'
-                                                              ( Inf'
-                                                                  { infixLeft =
-                                                                      Name'
-                                                                        (Sym "b" :| [])
-                                                                        (),
-                                                                    infixOp = Sym "->" :| [],
-                                                                    infixRight = Name' (Sym "c" :| []) (),
-                                                                    annInf = ()
-                                                                  }
-                                                              )
-                                                              (),
-                                                          annInf = ()
-                                                        }
-                                                    )
-                                                    (),
-                                                annInf = ()
-                                              }
-                                          )
-                                          ()
-                                      )
-                                      ()
-                                  ),
-                              annS = ()
-                            }
-                            :| [ S'
-                                   { sumConstructor = Sym "B",
-                                     sumValue =
-                                       Just
-                                         ( Arrow'
-                                             ( Infix'
-                                                 ( Inf'
-                                                     { infixLeft = Name' (Sym "d" :| []) (),
-                                                       infixOp = Sym "->" :| [],
-                                                       infixRight = Name' (Sym "Foo" :| []) (),
-                                                       annInf = ()
-                                                     }
-                                                 )
-                                                 ()
-                                             )
-                                             ()
-                                         ),
-                                     annS = ()
-                                   },
-                                 S'
-                                   { sumConstructor = Sym "C",
-                                     sumValue =
-                                       Just
-                                         ( Record'
-                                             ( Record'''
-                                                 { recordFields =
-                                                     NameType''
-                                                       { nameTypeSignature = Name' (Sym "Int" :| []) (),
-                                                         nameTypeName = Concrete' (Sym "a") (),
-                                                         annNameType' = ()
-                                                       }
-                                                       :| [ NameType''
-                                                              { nameTypeSignature = Name' (Sym "Int" :| []) (),
-                                                                nameTypeName = Implicit' (Sym "b") (),
-                                                                annNameType' = ()
-                                                              }
-                                                          ],
-                                                   recordFamilySignature = Nothing,
-                                                   annRecord'' = ()
-                                                 }
-                                             )
-                                             ()
-                                         ),
-                                     annS = ()
-                                   },
-                                 S'
-                                   { sumConstructor = Sym "D",
-                                     sumValue =
-                                       Just
-                                         ( Record'
-                                             ( Record'''
-                                                 { recordFields =
-                                                     NameType''
-                                                       { nameTypeSignature = Name' (Sym "Int" :| []) (),
-                                                         nameTypeName = Concrete' (Sym "a") (),
-                                                         annNameType' = ()
-                                                       }
-                                                       :| [ NameType''
-                                                              { nameTypeSignature =
-                                                                  Name' (Sym "Int" :| []) (),
-                                                                nameTypeName = Implicit' (Sym "b") (),
-                                                                annNameType' = ()
-                                                              }
-                                                          ],
-                                                   recordFamilySignature =
-                                                     Just
-                                                       ( Application'
-                                                           ( App'
-                                                               { applicationName = Name' (Sym "Foo" :| []) (),
-                                                                 applicationArgs =
-                                                                   Name' (Sym "Int" :| []) ()
-                                                                     :| [ Parened'
-                                                                            ( Infix'
-                                                                                ( Inf'
-                                                                                    { infixLeft = Name' (Sym "Fooy" :| []) (),
-                                                                                      infixOp = Sym "->" :| [],
-                                                                                      infixRight = Name' (Sym "Nada" :| []) (),
-                                                                                      annInf = ()
-                                                                                    }
-                                                                                )
-                                                                                ()
-                                                                            )
-                                                                            ()
-                                                                        ],
-                                                                 annApp = ()
-                                                               }
-                                                           )
-                                                           ()
-                                                       ),
-                                                   annRecord'' = ()
-                                                 }
-                                             )
-                                             ()
-                                         ),
-                                     annS = ()
-                                   }
-                               ]
-                        )
-                        (),
-                    annNonArrowed = ()
-                  },
-              annTyp = ()
-            }
-        )
-        ()
+    [ ( AST.Name (NameSymbol.fromSymbol "c")
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "b")) (NameSymbol.fromSymbol "->")
+          |> AST.Infix
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "a")) (NameSymbol.fromSymbol "->")
+          |> AST.Infix
+          |> AST.Inf (AST.Name (NameSymbol.fromSymbol "b")) (NameSymbol.fromSymbol ":")
+          |> AST.Infix
+          |> AST.Arrow
+          |> Just
+          |> AST.S "A"
+      )
+        :| [ AST.Name (NameSymbol.fromSymbol "Foo")
+               |> AST.Inf (AST.Name (NameSymbol.fromSymbol "d")) (NameSymbol.fromSymbol "->")
+               |> AST.Infix
+               |> AST.Arrow
+               |> Just
+               |> AST.S "B",
+             --
+             AST.NameType' (AST.Name (NameSymbol.fromSymbol "Int")) (AST.Concrete "a")
+               :| [AST.NameType' (AST.Name (NameSymbol.fromSymbol "Int")) (AST.Implicit "b")]
+               |> flip AST.Record'' Nothing
+               |> AST.Record
+               |> Just
+               |> AST.S "C",
+             --
+             (AST.Name (NameSymbol.fromSymbol "Int"))
+               :| [ (AST.Name (NameSymbol.fromSymbol "Nada"))
+                      |> AST.Inf
+                        (AST.Name (NameSymbol.fromSymbol "Fooy"))
+                        (NameSymbol.fromSymbol "->")
+                      |> AST.Infix
+                      |> AST.Parened
+                  ]
+               |> AST.App (AST.Name (NameSymbol.fromSymbol "Foo"))
+               |> AST.Application
+               |> Just
+               |> AST.Record''
+                 ( AST.NameType' (AST.Name (NameSymbol.fromSymbol "Int")) (AST.Concrete "a")
+                     :| [AST.NameType' (AST.Name (NameSymbol.fromSymbol "Int")) (AST.Implicit "b")]
+                 )
+               |> AST.Record
+               |> Just
+               |> AST.S "D"
+           ]
+        |> AST.Sum
+        |> AST.NonArrowed
+        |> AST.Typ Nothing "Foo" ["a", "b", "c"]
+        |> AST.Type
     ]
 
 --------------------------------------------------
@@ -939,7 +832,7 @@ vpsDashMiddle =
   isRight (parseOnly Parser.prefixSymbol "Foo-Foo")
 
 --------------------------------------------------------------------------------
--- Example(s) for REPL testing
+-- Examples for testing
 --------------------------------------------------------------------------------
 
 contractTest :: Either String [TopLevel]

--- a/test/Frontend/Parser.hs
+++ b/test/Frontend/Parser.hs
@@ -258,74 +258,28 @@ sigTest2 =
     "sigTest2"
     Parser.parse
     "sig foo 0 : i : Int{i > 0} -> Int{i > 1}"
-    [ Signature'
-        ( Sig'
-            { signatureName = Sym "foo",
-              signatureUsage = Just (Constant' (Number' (Integer'' 0 ()) ()) ()),
-              signatureArrowType =
-                Infix'
-                  ( Inf'
-                      { infixLeft = Name' (Sym "i" :| []) (),
-                        infixOp = Sym ":" :| [],
-                        infixRight =
-                          Infix'
-                            ( Inf'
-                                { infixLeft =
-                                    RefinedE'
-                                      ( TypeRefine'
-                                          { typeRefineName = Name' (Sym "Int" :| []) (),
-                                            typeRefineRefinement =
-                                              Infix'
-                                                ( Inf'
-                                                    { infixLeft = Name' (Sym "i" :| []) (),
-                                                      infixOp = Sym ">" :| [],
-                                                      infixRight = Constant' (Number' (Integer'' 0 ()) ()) (),
-                                                      annInf = ()
-                                                    }
-                                                )
-                                                (),
-                                            annTypeRefine = ()
-                                          }
-                                      )
-                                      (),
-                                  infixOp = Sym "->" :| [],
-                                  infixRight =
-                                    RefinedE'
-                                      ( TypeRefine'
-                                          { typeRefineName = Name' (Sym "Int" :| []) (),
-                                            typeRefineRefinement =
-                                              Infix'
-                                                ( Inf'
-                                                    { infixLeft = Name' (Sym "i" :| []) (),
-                                                      infixOp = Sym ">" :| [],
-                                                      infixRight =
-                                                        Constant'
-                                                          ( Number'
-                                                              (Integer'' 1 ())
-                                                              ()
-                                                          )
-                                                          (),
-                                                      annInf = ()
-                                                    }
-                                                )
-                                                (),
-                                            annTypeRefine = ()
-                                          }
-                                      )
-                                      (),
-                                  annInf = ()
-                                }
-                            )
-                            (),
-                        annInf = ()
-                      }
-                  )
-                  (),
-              signatureConstraints = [],
-              annSig = ()
-            }
-        )
-        ()
+    [ AST.Integer' 1
+        |> AST.Number
+        |> AST.Constant
+        |> AST.Inf (AST.Name (NameSymbol.fromSymbol "i")) (NameSymbol.fromSymbol ">")
+        |> AST.Infix
+        |> AST.TypeRefine (AST.Name (NameSymbol.fromSymbol "Int"))
+        |> AST.RefinedE
+        |> AST.Inf
+          ( AST.Integer' 0
+              |> AST.Number
+              |> AST.Constant
+              |> AST.Inf (AST.Name (NameSymbol.fromSymbol "i")) (NameSymbol.fromSymbol ">")
+              |> AST.Infix
+              |> AST.TypeRefine (AST.Name (NameSymbol.fromSymbol "Int"))
+              |> AST.RefinedE
+          )
+          (NameSymbol.fromSymbol "->")
+        |> AST.Infix
+        |> AST.Inf (AST.Name (NameSymbol.fromSymbol "i")) (NameSymbol.fromSymbol ":")
+        |> AST.Infix
+        |> flip (AST.Sig "foo" (Just (AST.Constant (AST.Number (AST.Integer' 0))))) []
+        |> AST.Signature
     ]
 
 -- --------------------------------------------------------------------------------

--- a/test/examples/Addition.ju.golden
+++ b/test/examples/Addition.ju.golden
@@ -1,1 +1,321 @@
-[Function' (Func' (Like' {functionLikedName = "nat", functionLikeArgs = [], functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["nat"]) ()) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "add", functionLikeArgs = [], functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["add"]) ()) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "pair", functionLikeArgs = [], functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["pair"]) ()) ()) (), annLike = ()}) ()) (),Type' (Typ' {typeUsage = Nothing, typeName' = "Storage", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("nat" :| []) (), nameTypeName = Concrete' "value" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = Name' ("nat" :| []) (), nameTypeName = Concrete' "valu" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) (),Signature' (Sig' {signatureName = "foo", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("nat" :| []) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("storage" :| []) (), infixOp = "->" :| [], infixRight = Name' ("storage" :| []) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "foo", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "va" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchRecord' (Punned' ("value" :| []) () :| [Punned' ("valu" :| []) ()]) (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (ExpRecord' (ExpressionRecord' {expRecordFields = NonPunned' ("value" :| []) (Application' (App' {applicationName = Name' ("add" :| []) (), applicationArgs = Name' ("valu" :| []) () :| [Name' ("va" :| []) ()], annApp = ()}) ()) () :| [NonPunned' ("valu" :| []) (Application' (App' {applicationName = Name' ("add" :| []) (), applicationArgs = Name' ("value" :| []) () :| [Name' ("va" :| []) ()], annApp = ()}) ()) ()], annExpressionRecord = ()}) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "add-storage", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("storage" :| []) (), infixOp = "->" :| [], infixRight = Name' ("nat" :| []) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "add-storage", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchRecord' (Punned' ("value" :| []) () :| [Punned' ("valu" :| []) ()]) (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Application' (App' {applicationName = Name' ("add" :| []) (), applicationArgs = Name' ("value" :| []) () :| [Name' ("valu" :| []) ()], annApp = ()}) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "default", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("nat" :| []) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("storage" :| []) (), infixOp = "->" :| [], infixRight = Name' ("storage" :| []) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "default", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "addnat" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "storage" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Application' (App' {applicationName = Name' ("pair" :| []) (), applicationArgs = Parened' (Application' (App' {applicationName = Name' ("add-storage" :| []) (), applicationArgs = Name' ("storage" :| []) () :| [], annApp = ()}) ()) () :| [Parened' (Application' (App' {applicationName = Name' ("foo" :| []) (), applicationArgs = Name' ("input" :| []) () :| [Name' ("storage" :| []) ()], annApp = ()}) ()) ()], annApp = ()}) ()) (), annLike = ()}) ()) ()]
+
+  [ Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "nat",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["nat"]) ()) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "add",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["add"]) ()) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "pair",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["pair"]) ()) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Type'
+      ( Typ'
+          { typeUsage = Nothing,
+            typeName' = "Storage",
+            typeArgs = [],
+            typeForm =
+              NonArrowed'
+                { dataAdt =
+                    Product'
+                      ( Record'
+                          ( Record'''
+                              { recordFields =
+                                  NameType''
+                                    { nameTypeSignature =
+                                        Name' ("nat" :| []) (),
+                                      nameTypeName = Concrete' "value" (),
+                                      annNameType' = ()
+                                    }
+                                    :| [ NameType''
+                                           { nameTypeSignature = Name' ("nat" :| []) (),
+                                             nameTypeName = Concrete' "valu" (),
+                                             annNameType' = ()
+                                           }
+                                       ],
+                                recordFamilySignature = Nothing,
+                                annRecord'' = ()
+                              }
+                          )
+                          ()
+                      )
+                      (),
+                  annNonArrowed = ()
+                },
+            annTyp = ()
+          }
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "foo",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("nat" :| []) (),
+                      infixOp = "->" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("storage" :| []) (),
+                                infixOp = "->" :| [],
+                                infixRight = Name' ("storage" :| []) (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "foo",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "va" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents =
+                              MatchRecord'
+                                ( Punned' ("value" :| []) ()
+                                    :| [Punned' ("valu" :| []) ()]
+                                )
+                                (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( ExpRecord'
+                        ( ExpressionRecord'
+                            { expRecordFields =
+                                NonPunned'
+                                  ("value" :| [])
+                                  ( Application'
+                                      ( App'
+                                          { applicationName = Name' ("add" :| []) (),
+                                            applicationArgs =
+                                              Name' ("valu" :| []) ()
+                                                :| [Name' ("va" :| []) ()],
+                                            annApp = ()
+                                          }
+                                      )
+                                      ()
+                                  )
+                                  ()
+                                  :| [ NonPunned'
+                                         ("valu" :| [])
+                                         ( Application'
+                                             ( App'
+                                                 { applicationName = Name' ("add" :| []) (),
+                                                   applicationArgs = Name' ("value" :| []) () :| [Name' ("va" :| []) ()],
+                                                   annApp = ()
+                                                 }
+                                             )
+                                             ()
+                                         )
+                                         ()
+                                     ],
+                              annExpressionRecord = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "add-storage",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("storage" :| []) (),
+                      infixOp = "->" :| [],
+                      infixRight = Name' ("nat" :| []) (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "add-storage",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents =
+                              MatchRecord'
+                                ( Punned' ("value" :| []) ()
+                                    :| [Punned' ("valu" :| []) ()]
+                                )
+                                (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Application'
+                        ( App'
+                            { applicationName = Name' ("add" :| []) (),
+                              applicationArgs = Name' ("value" :| []) () :| [Name' ("valu" :| []) ()],
+                              annApp = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "default",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("nat" :| []) (),
+                      infixOp = "->" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("storage" :| []) (),
+                                infixOp = "->" :| [],
+                                infixRight = Name' ("storage" :| []) (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "default",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "addnat" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "storage" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Application'
+                        ( App'
+                            { applicationName = Name' ("pair" :| []) (),
+                              applicationArgs =
+                                Parened'
+                                  ( Application'
+                                      ( App'
+                                          { applicationName = Name' ("add-storage" :| []) (),
+                                            applicationArgs = Name' ("storage" :| []) () :| [],
+                                            annApp = ()
+                                          }
+                                      )
+                                      ()
+                                  )
+                                  ()
+                                  :| [ Parened'
+                                         ( Application'
+                                             ( App'
+                                                 { applicationName = Name' ("foo" :| []) (),
+                                                   applicationArgs = Name' ("input" :| []) () :| [Name' ("storage" :| []) ()],
+                                                   annApp = ()
+                                                 }
+                                             )
+                                             ()
+                                         )
+                                         ()
+                                     ],
+                              annApp = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      ()
+  ]

--- a/test/examples/Id-Strings.ju.golden
+++ b/test/examples/Id-Strings.ju.golden
@@ -1,1 +1,140 @@
-[Function' (Func' (Like' {functionLikedName = "string", functionLikeArgs = [], functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["string"]) ()) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "pair", functionLikeArgs = [], functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["pair"]) ()) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "unit", functionLikeArgs = [], functionLikeBody = Body' (Primitive' (Prim' ("Param" :| ["unit"]) ()) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "storage", functionLikeArgs = [], functionLikeBody = Body' (Name' ("unit" :| []) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "default", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("string" :| []) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("storage" :| []) (), infixOp = "->" :| [], infixRight = Name' ("storage" :| []) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "default", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "para" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "storage" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Application' (App' {applicationName = Name' ("pair" :| []) (), applicationArgs = List' (ListLit' [] ()) () :| [Name' ("storage" :| []) ()], annApp = ()}) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "init-storage", signatureUsage = Nothing, signatureArrowType = Name' ("storage" :| []) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "init-storage", functionLikeArgs = [], functionLikeBody = Body' (Name' ("unit" :| []) ()) (), annLike = ()}) ()) ()]
+foo =
+  [ Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "string",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["string"]) ()) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "pair",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Primitive' (Prim' ("Michelson" :| ["pair"]) ()) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "unit",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Primitive' (Prim' ("Param" :| ["unit"]) ()) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "storage",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Name' ("unit" :| []) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "default",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("string" :| []) (),
+                      infixOp = "->" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("storage" :| []) (),
+                                infixOp = "->" :| [],
+                                infixRight = Name' ("storage" :| []) (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "default",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "para" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "storage" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Application'
+                        ( App'
+                            { applicationName = Name' ("pair" :| []) (),
+                              applicationArgs = List' (ListLit' [] ()) () :| [Name' ("storage" :| []) ()],
+                              annApp = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "init-storage",
+            signatureUsage = Nothing,
+            signatureArrowType = Name' ("storage" :| []) (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "init-storage",
+                functionLikeArgs = [],
+                functionLikeBody = Body' (Name' ("unit" :| []) ()) (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      ()
+  ]

--- a/test/examples/Id-Strings.ju.golden
+++ b/test/examples/Id-Strings.ju.golden
@@ -1,4 +1,4 @@
-foo =
+
   [ Function'
       ( Func'
           ( Like'

--- a/test/examples/Token.ju.golden
+++ b/test/examples/Token.ju.golden
@@ -1,4 +1,3 @@
-foo =
   [ Module'
       ( Mod'
           ( Like'

--- a/test/examples/Token.ju.golden
+++ b/test/examples/Token.ju.golden
@@ -1,1 +1,1612 @@
-[Module' (Mod' (Like' {functionLikedName = "Token", functionLikeArgs = [], functionLikeBody = Body' (Function' (Func' (Like' {functionLikedName = "Address", functionLikeArgs = [], functionLikeBody = Body' (Infix' (Inf' {infixLeft = Name' ("s" :| []) (), infixOp = ":" :| [], infixRight = RefinedE' (TypeRefine' {typeRefineName = Name' ("String" :| ["T"]) (), typeRefineRefinement = Infix' (Inf' {infixLeft = Application' (App' {applicationName = Name' ("String" :| ["length"]) (), applicationArgs = Name' ("s" :| []) () :| [], annApp = ()}) (), infixOp = "==" :| [], infixRight = Constant' (Number' (Integer'' 36 ()) ()) (), annInf = ()}) (), annTypeRefine = ()}) (), annInf = ()}) ()) (), annLike = ()}) ()) () :| [Type' (Typ' {typeUsage = Nothing, typeName' = "Storage", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("Nat" :| ["T"]) (), nameTypeName = Concrete' "total-supply" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = RefinedE' (TypeRefine' {typeRefineName = Name' ("Accounts" :| ["T"]) (), typeRefineRefinement = Infix' (Inf' {infixLeft = Name' ("Accounts" :| ["measure-value"]) (), infixOp = "==" :| [], infixRight = Name' ("total-supply" :| []) (), annInf = ()}) (), annTypeRefine = ()}) (), nameTypeName = Concrete' "accounts" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) (),Signature' (Sig' {signatureName = "empty-storage", signatureUsage = Nothing, signatureArrowType = Name' ("Storage" :| []) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "empty-storage", functionLikeArgs = [], functionLikeBody = Body' (ExpRecord' (ExpressionRecord' {expRecordFields = NonPunned' ("total-supply" :| []) (Constant' (Number' (Integer'' 0 ()) ()) ()) () :| [NonPunned' ("accounts" :| []) (Name' ("Accounts" :| ["empty"]) ()) ()], annExpressionRecord = ()}) ()) (), annLike = ()}) ()) (),Type' (Typ' {typeUsage = Nothing, typeName' = "T", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("Storage" :| []) (), nameTypeName = Concrete' "storage" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = Name' ("Nat" :| ["T"]) (), nameTypeName = Concrete' "version" (), annNameType' = ()},NameType'' {nameTypeSignature = Name' ("String" :| ["T"]) (), nameTypeName = Concrete' "name" (), annNameType' = ()},NameType'' {nameTypeSignature = Name' ("Char" :| ["T"]) (), nameTypeName = Concrete' "symbol" (), annNameType' = ()},NameType'' {nameTypeSignature = Name' ("Address" :| []) (), nameTypeName = Concrete' "owner" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) ()]) (), annLike = ()}) ()) (),Module' (Mod' (Like' {functionLikedName = "Transaction", functionLikeArgs = [], functionLikeBody = Body' (Type' (Typ' {typeUsage = Nothing, typeName' = "Transfer", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("Token" :| ["Address"]) (), nameTypeName = Concrete' "from-account" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = Name' ("Token" :| ["Address"]) (), nameTypeName = Concrete' "to-account" (), annNameType' = ()},NameType'' {nameTypeSignature = Name' ("Nat" :| ["T"]) (), nameTypeName = Concrete' "ammount" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) () :| [Type' (Typ' {typeUsage = Nothing, typeName' = "Mint", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("Nat" :| ["T"]) (), nameTypeName = Concrete' "mint-amount" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = Name' ("Token" :| ["Address"]) (), nameTypeName = Concrete' "mint-to-account" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) (),Type' (Typ' {typeUsage = Nothing, typeName' = "Burn", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("Nat" :| ["T"]) (), nameTypeName = Concrete' "burn-amount" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = Name' ("Token" :| ["Address"]) (), nameTypeName = Concrete' "burn-from-account" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) (),Type' (Typ' {typeUsage = Nothing, typeName' = "Data", typeArgs = [], typeForm = NonArrowed' {dataAdt = Sum' (S' {sumConstructor = "Transfer", sumValue = Just (Arrow' (Infix' (Inf' {infixLeft = Name' ("Transfer" :| []) (), infixOp = "->" :| [], infixRight = Name' ("Data" :| []) (), annInf = ()}) ()) ()), annS = ()} :| [S' {sumConstructor = "Mint", sumValue = Just (Arrow' (Infix' (Inf' {infixLeft = Name' ("Mint" :| []) (), infixOp = "->" :| [], infixRight = Name' ("Data" :| []) (), annInf = ()}) ()) ()), annS = ()},S' {sumConstructor = "Burn", sumValue = Just (Arrow' (Infix' (Inf' {infixLeft = Name' ("Burn" :| []) (), infixOp = "->" :| [], infixRight = Name' ("Data" :| []) (), annInf = ()}) ()) ()), annS = ()}]) (), annNonArrowed = ()}, annTyp = ()}) (),Type' (Typ' {typeUsage = Nothing, typeName' = "T", typeArgs = [], typeForm = NonArrowed' {dataAdt = Product' (Record' (Record''' {recordFields = NameType'' {nameTypeSignature = Name' ("Data" :| []) (), nameTypeName = Concrete' "data" (), annNameType' = ()} :| [NameType'' {nameTypeSignature = Name' ("Token" :| ["Address"]) (), nameTypeName = Concrete' "authorized-account" (), annNameType' = ()}], recordFamilySignature = Nothing, annRecord'' = ()}) ()) (), annNonArrowed = ()}, annTyp = ()}) ()]) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "has-n", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("Accounts" :| ["T"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Token" :| ["Address"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Nat" :| []) (), infixOp = "->" :| [], infixRight = Name' ("Bool" :| []) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "has-n", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "accounts" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "add" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "to-transfer" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Match' (Match''' {matchOn = Application' (App' {applicationName = Name' ("Accounts" :| ["select"]) (), applicationArgs = Name' ("accounts" :| []) () :| [Name' ("add" :| []) ()], annApp = ()}) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Just" :| []) [MatchLogic' {matchLogicContents = MatchName' "n" (), matchLogicNamed = Nothing, annMatchLogic = ()}] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Infix' (Inf' {infixLeft = Name' ("to-transfer" :| []) (), infixOp = "<=" :| [], infixRight = Name' ("n" :| []) (), annInf = ()}) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Nothing" :| []) [] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Name' ("False" :| []) (), annMatchL = ()}], annMatch'' = ()}) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "account-sub", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("acc" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Accounts" :| ["T"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("add" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Token" :| ["Address"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("num" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = RefinedE' (TypeRefine' {typeRefineName = Name' ("Nat" :| ["T"]) (), typeRefineRefinement = Application' (App' {applicationName = Name' ("has-n" :| []) (), applicationArgs = Name' ("acc" :| []) () :| [Name' ("add" :| []) (),Name' ("num" :| []) ()], annApp = ()}) (), annTypeRefine = ()}) (), infixOp = "->" :| [], infixRight = Name' ("Accounts" :| ["T"]) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "account-sub", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "accounts" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "add" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "number" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Match' (Match''' {matchOn = Application' (App' {applicationName = Name' ("Accounts" :| ["select"]) (), applicationArgs = Name' ("accounts" :| []) () :| [Name' ("add" :| []) ()], annApp = ()}) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Just" :| []) [MatchLogic' {matchLogicContents = MatchName' "balance" (), matchLogicNamed = Nothing, annMatchLogic = ()}] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Application' (App' {applicationName = Name' ("Accounts" :| ["put"]) (), applicationArgs = Name' ("accounts" :| []) () :| [Name' ("add" :| []) (),Parened' (Infix' (Inf' {infixLeft = Name' ("balance" :| []) (), infixOp = "-" :| [], infixRight = Name' ("number" :| []) (), annInf = ()}) ()) ()], annApp = ()}) (), annMatchL = ()} :| [], annMatch'' = ()}) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "account-add", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("Accounts" :| ["T"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Token" :| ["Address"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Nat" :| ["T"]) (), infixOp = "->" :| [], infixRight = Name' ("Accounts" :| ["T"]) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "account-add", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "accounts" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "add" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "number" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Application' (App' {applicationName = Name' ("Accounts" :| ["update"]) (), applicationArgs = Name' ("accounts" :| []) () :| [Parened' (Application' (App' {applicationName = Name' ("+" :| []) (), applicationArgs = Name' ("number" :| []) () :| [], annApp = ()}) ()) (),Name' ("add" :| []) ()], annApp = ()}) ()) (), annLike = ()}) ()) (),Signature' (Sig' {signatureName = "transfer-stor", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("stor" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Token" :| ["Storage"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("from" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Token" :| ["Address"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("to" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Token" :| ["Address"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("num" :| []) (), infixOp = ":" :| [], infixRight = Infix' (Inf' {infixLeft = RefinedE' (TypeRefine' {typeRefineName = Name' ("Nat" :| ["T"]) (), typeRefineRefinement = Application' (App' {applicationName = Name' ("has-n" :| []) (), applicationArgs = Name' ("stor" :| ["accounts"]) () :| [Name' ("from" :| []) (),Name' ("num" :| []) ()], annApp = ()}) (), annTypeRefine = ()}) (), infixOp = "->" :| [], infixRight = Name' ("Token" :| ["Storage"]) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "transfer-stor", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "stor" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "add-from" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "add-to" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "num" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Let' (Let''' {letBindings = Like' {functionLikedName = "new-acc", functionLikeArgs = [], functionLikeBody = Body' (Application' (App' {applicationName = Name' ("account-add" :| []) (), applicationArgs = Parened' (Application' (App' {applicationName = Name' ("account-sub" :| []) (), applicationArgs = Name' ("stor" :| ["accounts"]) () :| [Name' ("add-from" :| []) ()], annApp = ()}) ()) () :| [Name' ("add-to" :| []) (),Name' ("num" :| []) ()], annApp = ()}) ()) (), annLike = ()}, letBody = ExpRecord' (ExpressionRecord' {expRecordFields = NonPunned' ("total-supply" :| []) (Name' ("stor" :| ["total-supply"]) ()) () :| [NonPunned' ("accounts" :| []) (Name' ("new-acc" :| []) ()) ()], annExpressionRecord = ()}) (), annLet'' = ()}) ()) (), annLike = ()}) ()) (),Module' (Mod' (Like' {functionLikedName = "Validation", functionLikeArgs = [], functionLikeBody = Body' (Function' (Func' (Like' {functionLikedName = "T", functionLikeArgs = [], functionLikeBody = Body' (Infix' (Inf' {infixLeft = Name' ("Token" :| ["T"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Transaction" :| ["T"]) (), infixOp = "->" :| [], infixRight = Name' ("Bool" :| []) (), annInf = ()}) (), annInf = ()}) ()) (), annLike = ()}) ()) () :| [Function' (Func' (Like' {functionLikedName = "mint", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "token" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "tx" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Match' (Match''' {matchOn = Name' ("tx" :| ["data"]) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Transaction" :| ["Mint"]) [] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Infix' (Inf' {infixLeft = Name' ("token" :| ["owner"]) (), infixOp = "==" :| [], infixRight = Name' ("tx" :| ["authorized-account"]) (), annInf = ()}) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchName' "_" (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Name' ("false" :| []) (), annMatchL = ()}], annMatch'' = ()}) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "transfer", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "token" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "tx" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Match' (Match''' {matchOn = Name' ("tx" :| ["data"]) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Transaction" :| ["Transfer"]) [MatchLogic' {matchLogicContents = MatchRecord' (Punned' ("from-account" :| []) () :| [Punned' ("amount" :| []) ()]) (), matchLogicNamed = Nothing, annMatchLogic = ()}] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Infix' (Inf' {infixLeft = Application' (App' {applicationName = Name' ("has-n" :| []) (), applicationArgs = Name' ("token" :| ["storage","accounts"]) () :| [Name' ("from-account" :| []) (),Name' ("amount" :| []) ()], annApp = ()}) (), infixOp = "&&" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("tx" :| ["authorized-account"]) (), infixOp = "==" :| [], infixRight = Name' ("from-account" :| []) (), annInf = ()}) (), annInf = ()}) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchName' "_" (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Name' ("false" :| []) (), annMatchL = ()}], annMatch'' = ()}) ()) (), annLike = ()}) ()) (),Function' (Func' (Like' {functionLikedName = "Burn", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "token" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "tx" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Match' (Match''' {matchOn = Name' ("tx" :| ["data"]) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Transaction" :| ["Burn"]) [MatchLogic' {matchLogicContents = MatchRecord' (Punned' ("burn-from-account" :| []) () :| [Punned' ("burn-amount" :| []) ()]) (), matchLogicNamed = Nothing, annMatchLogic = ()}] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Infix' (Inf' {infixLeft = Application' (App' {applicationName = Name' ("has-n" :| []) (), applicationArgs = Name' ("token" :| ["storage","accounts"]) () :| [Name' ("burn-from-account" :| []) (),Name' ("burn-amount" :| []) ()], annApp = ()}) (), infixOp = "&&" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("tx" :| ["authorized-account"]) (), infixOp = "==" :| [], infixRight = Name' ("burn-from-account" :| []) (), annInf = ()}) (), annInf = ()}) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchName' "_" (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Name' ("false" :| []) (), annMatchL = ()}], annMatch'' = ()}) ()) (), annLike = ()}) ()) ()]) (), annLike = ()}) ()) (),Type' (Typ' {typeUsage = Nothing, typeName' = "Error", typeArgs = [], typeForm = NonArrowed' {dataAdt = Sum' (S' {sumConstructor = "NotEnoughFunds", sumValue = Just (ADTLike' [] ()), annS = ()} :| [S' {sumConstructor = "NotSameAccount", sumValue = Just (ADTLike' [] ()), annS = ()},S' {sumConstructor = "NotOwnerToken", sumValue = Just (ADTLike' [] ()), annS = ()},S' {sumConstructor = "NotEnoughTokens", sumValue = Just (ADTLike' [] ()), annS = ()}]) (), annNonArrowed = ()}, annTyp = ()}) (),Signature' (Sig' {signatureName = "exec", signatureUsage = Nothing, signatureArrowType = Infix' (Inf' {infixLeft = Name' ("Token" :| ["T"]) (), infixOp = "->" :| [], infixRight = Infix' (Inf' {infixLeft = Name' ("Transaction" :| ["T"]) (), infixOp = "->" :| [], infixRight = Application' (App' {applicationName = Name' ("Either" :| ["T"]) (), applicationArgs = Name' ("Error" :| []) () :| [Name' ("Token" :| ["T"]) ()], annApp = ()}) (), annInf = ()}) (), annInf = ()}) (), signatureConstraints = [], annSig = ()}) (),Function' (Func' (Like' {functionLikedName = "exec", functionLikeArgs = [ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "token" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "tx" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()], functionLikeBody = Body' (Match' (Match''' {matchOn = Name' ("tx" :| ["data"]) (), matchBindigns = MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Transfer" :| []) [MatchLogic' {matchLogicContents = MatchName' "_" (), matchLogicNamed = Nothing, annMatchLogic = ()}] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Cond' (C' (CondExpression' {condLogicPred = Application' (App' {applicationName = Name' ("Validation" :| ["transfer"]) (), applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()], annApp = ()}) (), condLogicBody = Application' (App' {applicationName = Name' ("Right" :| []) (), applicationArgs = Parened' (Application' (App' {applicationName = Name' ("transfer" :| []) (), applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()], annApp = ()}) ()) () :| [], annApp = ()}) (), annCondExpression = ()} :| [CondExpression' {condLogicPred = Name' ("else" :| []) (), condLogicBody = Application' (App' {applicationName = Name' ("Left" :| []) (), applicationArgs = Name' ("NotEnoughFunds" :| []) () :| [], annApp = ()}) (), annCondExpression = ()}]) ()) (), annMatchL = ()} :| [MatchL' {matchLPattern = MatchLogic' {matchLogicContents = MatchCon' ("Mint" :| []) [MatchLogic' {matchLogicContents = MatchName' "_" (), matchLogicNamed = Nothing, annMatchLogic = ()}] (), matchLogicNamed = Nothing, annMatchLogic = ()}, matchLBody = Cond' (C' (CondExpression' {condLogicPred = Application' (App' {applicationName = Name' ("Validation" :| ["mint"]) (), applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()], annApp = ()}) (), condLogicBody = Application' (App' {applicationName = Name' ("Right" :| []) (), applicationArgs = Parened' (Application' (App' {applicationName = Name' ("mint" :| []) (), applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()], annApp = ()}) ()) () :| [], annApp = ()}) (), annCondExpression = ()} :| [CondExpression' {condLogicPred = Name' ("else" :| []) (), condLogicBody = Application' (App' {applicationName = Name' ("Left" :| []) (), applicationArgs = Name' ("NotEnoughFunds" :| []) () :| [], annApp = ()}) (), annCondExpression = ()}]) ()) (), annMatchL = ()}], annMatch'' = ()}) ()) (), annLike = ()}) ()) ()]
+foo =
+  [ Module'
+      ( Mod'
+          ( Like'
+              { functionLikedName = "Token",
+                functionLikeArgs = [],
+                functionLikeBody =
+                  Body'
+                    ( Function'
+                        ( Func'
+                            ( Like'
+                                { functionLikedName = "Address",
+                                  functionLikeArgs = [],
+                                  functionLikeBody =
+                                    Body'
+                                      ( Infix'
+                                          ( Inf'
+                                              { infixLeft = Name' ("s" :| []) (),
+                                                infixOp = ":" :| [],
+                                                infixRight =
+                                                  RefinedE'
+                                                    ( TypeRefine'
+                                                        { typeRefineName = Name' ("String" :| ["T"]) (),
+                                                          typeRefineRefinement =
+                                                            Infix'
+                                                              ( Inf'
+                                                                  { infixLeft =
+                                                                      Application'
+                                                                        ( App'
+                                                                            { applicationName = Name' ("String" :| ["length"]) (),
+                                                                              applicationArgs = Name' ("s" :| []) () :| [],
+                                                                              annApp = ()
+                                                                            }
+                                                                        )
+                                                                        (),
+                                                                    infixOp = "==" :| [],
+                                                                    infixRight = Constant' (Number' (Integer'' 36 ()) ()) (),
+                                                                    annInf = ()
+                                                                  }
+                                                              )
+                                                              (),
+                                                          annTypeRefine = ()
+                                                        }
+                                                    )
+                                                    (),
+                                                annInf = ()
+                                              }
+                                          )
+                                          ()
+                                      )
+                                      (),
+                                  annLike = ()
+                                }
+                            )
+                            ()
+                        )
+                        ()
+                        :| [ Type'
+                               ( Typ'
+                                   { typeUsage = Nothing,
+                                     typeName' = "Storage",
+                                     typeArgs = [],
+                                     typeForm =
+                                       NonArrowed'
+                                         { dataAdt =
+                                             Product'
+                                               ( Record'
+                                                   ( Record'''
+                                                       { recordFields =
+                                                           NameType''
+                                                             { nameTypeSignature =
+                                                                 Name'
+                                                                   ("Nat" :| ["T"])
+                                                                   (),
+                                                               nameTypeName = Concrete' "total-supply" (),
+                                                               annNameType' = ()
+                                                             }
+                                                             :| [ NameType''
+                                                                    { nameTypeSignature =
+                                                                        RefinedE'
+                                                                          ( TypeRefine'
+                                                                              { typeRefineName = Name' ("Accounts" :| ["T"]) (),
+                                                                                typeRefineRefinement =
+                                                                                  Infix'
+                                                                                    ( Inf'
+                                                                                        { infixLeft = Name' ("Accounts" :| ["measure-value"]) (),
+                                                                                          infixOp = "==" :| [],
+                                                                                          infixRight = Name' ("total-supply" :| []) (),
+                                                                                          annInf = ()
+                                                                                        }
+                                                                                    )
+                                                                                    (),
+                                                                                annTypeRefine = ()
+                                                                              }
+                                                                          )
+                                                                          (),
+                                                                      nameTypeName = Concrete' "accounts" (),
+                                                                      annNameType' = ()
+                                                                    }
+                                                                ],
+                                                         recordFamilySignature = Nothing,
+                                                         annRecord'' = ()
+                                                       }
+                                                   )
+                                                   ()
+                                               )
+                                               (),
+                                           annNonArrowed = ()
+                                         },
+                                     annTyp = ()
+                                   }
+                               )
+                               (),
+                             Signature'
+                               ( Sig'
+                                   { signatureName = "empty-storage",
+                                     signatureUsage = Nothing,
+                                     signatureArrowType = Name' ("Storage" :| []) (),
+                                     signatureConstraints = [],
+                                     annSig = ()
+                                   }
+                               )
+                               (),
+                             Function'
+                               ( Func'
+                                   ( Like'
+                                       { functionLikedName = "empty-storage",
+                                         functionLikeArgs = [],
+                                         functionLikeBody =
+                                           Body'
+                                             ( ExpRecord'
+                                                 ( ExpressionRecord'
+                                                     { expRecordFields =
+                                                         NonPunned' ("total-supply" :| []) (Constant' (Number' (Integer'' 0 ()) ()) ()) ()
+                                                           :| [ NonPunned'
+                                                                  ("accounts" :| [])
+                                                                  (Name' ("Accounts" :| ["empty"]) ())
+                                                                  ()
+                                                              ],
+                                                       annExpressionRecord = ()
+                                                     }
+                                                 )
+                                                 ()
+                                             )
+                                             (),
+                                         annLike = ()
+                                       }
+                                   )
+                                   ()
+                               )
+                               (),
+                             Type'
+                               ( Typ'
+                                   { typeUsage = Nothing,
+                                     typeName' = "T",
+                                     typeArgs = [],
+                                     typeForm =
+                                       NonArrowed'
+                                         { dataAdt =
+                                             Product'
+                                               ( Record'
+                                                   ( Record'''
+                                                       { recordFields =
+                                                           NameType''
+                                                             { nameTypeSignature = Name' ("Storage" :| []) (),
+                                                               nameTypeName = Concrete' "storage" (),
+                                                               annNameType' = ()
+                                                             }
+                                                             :| [ NameType''
+                                                                    { nameTypeSignature = Name' ("Nat" :| ["T"]) (),
+                                                                      nameTypeName = Concrete' "version" (),
+                                                                      annNameType' = ()
+                                                                    },
+                                                                  NameType''
+                                                                    { nameTypeSignature = Name' ("String" :| ["T"]) (),
+                                                                      nameTypeName = Concrete' "name" (),
+                                                                      annNameType' = ()
+                                                                    },
+                                                                  NameType''
+                                                                    { nameTypeSignature = Name' ("Char" :| ["T"]) (),
+                                                                      nameTypeName = Concrete' "symbol" (),
+                                                                      annNameType' = ()
+                                                                    },
+                                                                  NameType''
+                                                                    { nameTypeSignature = Name' ("Address" :| []) (),
+                                                                      nameTypeName = Concrete' "owner" (),
+                                                                      annNameType' = ()
+                                                                    }
+                                                                ],
+                                                         recordFamilySignature = Nothing,
+                                                         annRecord'' = ()
+                                                       }
+                                                   )
+                                                   ()
+                                               )
+                                               (),
+                                           annNonArrowed = ()
+                                         },
+                                     annTyp = ()
+                                   }
+                               )
+                               ()
+                           ]
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Module'
+      ( Mod'
+          ( Like'
+              { functionLikedName = "Transaction",
+                functionLikeArgs = [],
+                functionLikeBody =
+                  Body'
+                    ( Type'
+                        ( Typ'
+                            { typeUsage = Nothing,
+                              typeName' = "Transfer",
+                              typeArgs = [],
+                              typeForm =
+                                NonArrowed'
+                                  { dataAdt =
+                                      Product'
+                                        ( Record'
+                                            ( Record'''
+                                                { recordFields =
+                                                    NameType''
+                                                      { nameTypeSignature = Name' ("Token" :| ["Address"]) (),
+                                                        nameTypeName = Concrete' "from-account" (),
+                                                        annNameType' = ()
+                                                      }
+                                                      :| [ NameType''
+                                                             { nameTypeSignature = Name' ("Token" :| ["Address"]) (),
+                                                               nameTypeName = Concrete' "to-account" (),
+                                                               annNameType' = ()
+                                                             },
+                                                           NameType''
+                                                             { nameTypeSignature = Name' ("Nat" :| ["T"]) (),
+                                                               nameTypeName = Concrete' "ammount" (),
+                                                               annNameType' = ()
+                                                             }
+                                                         ],
+                                                  recordFamilySignature = Nothing,
+                                                  annRecord'' = ()
+                                                }
+                                            )
+                                            ()
+                                        )
+                                        (),
+                                    annNonArrowed = ()
+                                  },
+                              annTyp = ()
+                            }
+                        )
+                        ()
+                        :| [ Type'
+                               ( Typ'
+                                   { typeUsage = Nothing,
+                                     typeName' = "Mint",
+                                     typeArgs = [],
+                                     typeForm =
+                                       NonArrowed'
+                                         { dataAdt =
+                                             Product'
+                                               ( Record'
+                                                   ( Record'''
+                                                       { recordFields =
+                                                           NameType''
+                                                             { nameTypeSignature = Name' ("Nat" :| ["T"]) (),
+                                                               nameTypeName = Concrete' "mint-amount" (),
+                                                               annNameType' = ()
+                                                             }
+                                                             :| [ NameType''
+                                                                    { nameTypeSignature = Name' ("Token" :| ["Address"]) (),
+                                                                      nameTypeName = Concrete' "mint-to-account" (),
+                                                                      annNameType' = ()
+                                                                    }
+                                                                ],
+                                                         recordFamilySignature = Nothing,
+                                                         annRecord'' = ()
+                                                       }
+                                                   )
+                                                   ()
+                                               )
+                                               (),
+                                           annNonArrowed = ()
+                                         },
+                                     annTyp = ()
+                                   }
+                               )
+                               (),
+                             Type'
+                               ( Typ'
+                                   { typeUsage = Nothing,
+                                     typeName' = "Burn",
+                                     typeArgs = [],
+                                     typeForm =
+                                       NonArrowed'
+                                         { dataAdt =
+                                             Product'
+                                               ( Record'
+                                                   ( Record'''
+                                                       { recordFields =
+                                                           NameType''
+                                                             { nameTypeSignature = Name' ("Nat" :| ["T"]) (),
+                                                               nameTypeName = Concrete' "burn-amount" (),
+                                                               annNameType' = ()
+                                                             }
+                                                             :| [ NameType''
+                                                                    { nameTypeSignature = Name' ("Token" :| ["Address"]) (),
+                                                                      nameTypeName = Concrete' "burn-from-account" (),
+                                                                      annNameType' = ()
+                                                                    }
+                                                                ],
+                                                         recordFamilySignature = Nothing,
+                                                         annRecord'' = ()
+                                                       }
+                                                   )
+                                                   ()
+                                               )
+                                               (),
+                                           annNonArrowed = ()
+                                         },
+                                     annTyp = ()
+                                   }
+                               )
+                               (),
+                             Type'
+                               ( Typ'
+                                   { typeUsage = Nothing,
+                                     typeName' = "Data",
+                                     typeArgs = [],
+                                     typeForm =
+                                       NonArrowed'
+                                         { dataAdt =
+                                             Sum'
+                                               ( S'
+                                                   { sumConstructor = "Transfer",
+                                                     sumValue =
+                                                       Just
+                                                         ( Arrow'
+                                                             ( Infix'
+                                                                 ( Inf'
+                                                                     { infixLeft = Name' ("Transfer" :| []) (),
+                                                                       infixOp = "->" :| [],
+                                                                       infixRight = Name' ("Data" :| []) (),
+                                                                       annInf = ()
+                                                                     }
+                                                                 )
+                                                                 ()
+                                                             )
+                                                             ()
+                                                         ),
+                                                     annS = ()
+                                                   }
+                                                   :| [ S'
+                                                          { sumConstructor = "Mint",
+                                                            sumValue =
+                                                              Just
+                                                                ( Arrow'
+                                                                    ( Infix'
+                                                                        ( Inf'
+                                                                            { infixLeft = Name' ("Mint" :| []) (),
+                                                                              infixOp = "->" :| [],
+                                                                              infixRight = Name' ("Data" :| []) (),
+                                                                              annInf = ()
+                                                                            }
+                                                                        )
+                                                                        ()
+                                                                    )
+                                                                    ()
+                                                                ),
+                                                            annS = ()
+                                                          },
+                                                        S'
+                                                          { sumConstructor = "Burn",
+                                                            sumValue =
+                                                              Just
+                                                                ( Arrow'
+                                                                    ( Infix'
+                                                                        ( Inf'
+                                                                            { infixLeft = Name' ("Burn" :| []) (),
+                                                                              infixOp = "->" :| [],
+                                                                              infixRight = Name' ("Data" :| []) (),
+                                                                              annInf = ()
+                                                                            }
+                                                                        )
+                                                                        ()
+                                                                    )
+                                                                    ()
+                                                                ),
+                                                            annS = ()
+                                                          }
+                                                      ]
+                                               )
+                                               (),
+                                           annNonArrowed = ()
+                                         },
+                                     annTyp = ()
+                                   }
+                               )
+                               (),
+                             Type'
+                               ( Typ'
+                                   { typeUsage = Nothing,
+                                     typeName' = "T",
+                                     typeArgs = [],
+                                     typeForm =
+                                       NonArrowed'
+                                         { dataAdt =
+                                             Product'
+                                               ( Record'
+                                                   ( Record'''
+                                                       { recordFields =
+                                                           NameType''
+                                                             { nameTypeSignature = Name' ("Data" :| []) (),
+                                                               nameTypeName = Concrete' "data" (),
+                                                               annNameType' = ()
+                                                             }
+                                                             :| [ NameType''
+                                                                    { nameTypeSignature = Name' ("Token" :| ["Address"]) (),
+                                                                      nameTypeName = Concrete' "authorized-account" (),
+                                                                      annNameType' = ()
+                                                                    }
+                                                                ],
+                                                         recordFamilySignature = Nothing,
+                                                         annRecord'' = ()
+                                                       }
+                                                   )
+                                                   ()
+                                               )
+                                               (),
+                                           annNonArrowed = ()
+                                         },
+                                     annTyp = ()
+                                   }
+                               )
+                               ()
+                           ]
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "has-n",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("Accounts" :| ["T"]) (),
+                      infixOp = "->" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("Token" :| ["Address"]) (),
+                                infixOp = "->" :| [],
+                                infixRight =
+                                  Infix'
+                                    ( Inf'
+                                        { infixLeft = Name' ("Nat" :| []) (),
+                                          infixOp = "->" :| [],
+                                          infixRight = Name' ("Bool" :| []) (),
+                                          annInf = ()
+                                        }
+                                    )
+                                    (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "has-n",
+                functionLikeArgs =
+                  [ ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "accounts" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "add" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "to-transfer" (), matchLogicNamed = Nothing, annMatchLogic = ()}) ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Match'
+                        ( Match'''
+                            { matchOn =
+                                Application'
+                                  ( App'
+                                      { applicationName = Name' ("Accounts" :| ["select"]) (),
+                                        applicationArgs = Name' ("accounts" :| []) () :| [Name' ("add" :| []) ()],
+                                        annApp = ()
+                                      }
+                                  )
+                                  (),
+                              matchBindigns =
+                                MatchL'
+                                  { matchLPattern =
+                                      MatchLogic'
+                                        { matchLogicContents =
+                                            MatchCon'
+                                              ("Just" :| [])
+                                              [ MatchLogic'
+                                                  { matchLogicContents = MatchName' "n" (),
+                                                    matchLogicNamed = Nothing,
+                                                    annMatchLogic = ()
+                                                  }
+                                              ]
+                                              (),
+                                          matchLogicNamed = Nothing,
+                                          annMatchLogic = ()
+                                        },
+                                    matchLBody =
+                                      Infix'
+                                        ( Inf'
+                                            { infixLeft = Name' ("to-transfer" :| []) (),
+                                              infixOp = "<=" :| [],
+                                              infixRight = Name' ("n" :| []) (),
+                                              annInf = ()
+                                            }
+                                        )
+                                        (),
+                                    annMatchL = ()
+                                  }
+                                  :| [ MatchL'
+                                         { matchLPattern =
+                                             MatchLogic'
+                                               { matchLogicContents = MatchCon' ("Nothing" :| []) [] (),
+                                                 matchLogicNamed = Nothing,
+                                                 annMatchLogic = ()
+                                               },
+                                           matchLBody = Name' ("False" :| []) (),
+                                           annMatchL = ()
+                                         }
+                                     ],
+                              annMatch'' = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "account-sub",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("acc" :| []) (),
+                      infixOp = ":" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("Accounts" :| ["T"]) (),
+                                infixOp = "->" :| [],
+                                infixRight =
+                                  Infix'
+                                    ( Inf'
+                                        { infixLeft = Name' ("add" :| []) (),
+                                          infixOp = ":" :| [],
+                                          infixRight =
+                                            Infix'
+                                              ( Inf'
+                                                  { infixLeft = Name' ("Token" :| ["Address"]) (),
+                                                    infixOp = "->" :| [],
+                                                    infixRight =
+                                                      Infix'
+                                                        ( Inf'
+                                                            { infixLeft = Name' ("num" :| []) (),
+                                                              infixOp = ":" :| [],
+                                                              infixRight =
+                                                                Infix'
+                                                                  ( Inf'
+                                                                      { infixLeft =
+                                                                          RefinedE'
+                                                                            ( TypeRefine'
+                                                                                { typeRefineName = Name' ("Nat" :| ["T"]) (),
+                                                                                  typeRefineRefinement =
+                                                                                    Application'
+                                                                                      ( App'
+                                                                                          { applicationName = Name' ("has-n" :| []) (),
+                                                                                            applicationArgs =
+                                                                                              Name' ("acc" :| []) ()
+                                                                                                :| [ Name'
+                                                                                                       ("add" :| [])
+                                                                                                       (),
+                                                                                                     Name' ("num" :| []) ()
+                                                                                                   ],
+                                                                                            annApp = ()
+                                                                                          }
+                                                                                      )
+                                                                                      (),
+                                                                                  annTypeRefine = ()
+                                                                                }
+                                                                            )
+                                                                            (),
+                                                                        infixOp = "->" :| [],
+                                                                        infixRight = Name' ("Accounts" :| ["T"]) (),
+                                                                        annInf = ()
+                                                                      }
+                                                                  )
+                                                                  (),
+                                                              annInf = ()
+                                                            }
+                                                        )
+                                                        (),
+                                                    annInf = ()
+                                                  }
+                                              )
+                                              (),
+                                          annInf = ()
+                                        }
+                                    )
+                                    (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "account-sub",
+                functionLikeArgs =
+                  [ ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "accounts" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),
+                    ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "add" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "number" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Match'
+                        ( Match'''
+                            { matchOn =
+                                Application'
+                                  ( App'
+                                      { applicationName = Name' ("Accounts" :| ["select"]) (),
+                                        applicationArgs = Name' ("accounts" :| []) () :| [Name' ("add" :| []) ()],
+                                        annApp = ()
+                                      }
+                                  )
+                                  (),
+                              matchBindigns =
+                                MatchL'
+                                  { matchLPattern =
+                                      MatchLogic'
+                                        { matchLogicContents =
+                                            MatchCon'
+                                              ("Just" :| [])
+                                              [ MatchLogic'
+                                                  { matchLogicContents = MatchName' "balance" (),
+                                                    matchLogicNamed = Nothing,
+                                                    annMatchLogic = ()
+                                                  }
+                                              ]
+                                              (),
+                                          matchLogicNamed = Nothing,
+                                          annMatchLogic = ()
+                                        },
+                                    matchLBody =
+                                      Application'
+                                        ( App'
+                                            { applicationName =
+                                                Name'
+                                                  ("Accounts" :| ["put"])
+                                                  (),
+                                              applicationArgs =
+                                                Name' ("accounts" :| []) ()
+                                                  :| [ Name' ("add" :| []) (),
+                                                       Parened'
+                                                         ( Infix'
+                                                             ( Inf'
+                                                                 { infixLeft = Name' ("balance" :| []) (),
+                                                                   infixOp = "-" :| [],
+                                                                   infixRight = Name' ("number" :| []) (),
+                                                                   annInf = ()
+                                                                 }
+                                                             )
+                                                             ()
+                                                         )
+                                                         ()
+                                                     ],
+                                              annApp = ()
+                                            }
+                                        )
+                                        (),
+                                    annMatchL = ()
+                                  }
+                                  :| [],
+                              annMatch'' = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "account-add",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("Accounts" :| ["T"]) (),
+                      infixOp = "->" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("Token" :| ["Address"]) (),
+                                infixOp = "->" :| [],
+                                infixRight =
+                                  Infix'
+                                    ( Inf'
+                                        { infixLeft = Name' ("Nat" :| ["T"]) (),
+                                          infixOp = "->" :| [],
+                                          infixRight = Name' ("Accounts" :| ["T"]) (),
+                                          annInf = ()
+                                        }
+                                    )
+                                    (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "account-add",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "accounts" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "add" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "number" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Application'
+                        ( App'
+                            { applicationName = Name' ("Accounts" :| ["update"]) (),
+                              applicationArgs =
+                                Name' ("accounts" :| []) ()
+                                  :| [ Parened'
+                                         ( Application'
+                                             ( App'
+                                                 { applicationName = Name' ("+" :| []) (),
+                                                   applicationArgs = Name' ("number" :| []) () :| [],
+                                                   annApp = ()
+                                                 }
+                                             )
+                                             ()
+                                         )
+                                         (),
+                                       Name' ("add" :| []) ()
+                                     ],
+                              annApp = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "transfer-stor",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("stor" :| []) (),
+                      infixOp = ":" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("Token" :| ["Storage"]) (),
+                                infixOp = "->" :| [],
+                                infixRight =
+                                  Infix'
+                                    ( Inf'
+                                        { infixLeft = Name' ("from" :| []) (),
+                                          infixOp = ":" :| [],
+                                          infixRight =
+                                            Infix'
+                                              ( Inf'
+                                                  { infixLeft = Name' ("Token" :| ["Address"]) (),
+                                                    infixOp = "->" :| [],
+                                                    infixRight =
+                                                      Infix'
+                                                        ( Inf'
+                                                            { infixLeft = Name' ("to" :| []) (),
+                                                              infixOp = ":" :| [],
+                                                              infixRight =
+                                                                Infix'
+                                                                  ( Inf'
+                                                                      { infixLeft = Name' ("Token" :| ["Address"]) (),
+                                                                        infixOp = "->" :| [],
+                                                                        infixRight =
+                                                                          Infix'
+                                                                            ( Inf'
+                                                                                { infixLeft = Name' ("num" :| []) (),
+                                                                                  infixOp = ":" :| [],
+                                                                                  infixRight =
+                                                                                    Infix'
+                                                                                      ( Inf'
+                                                                                          { infixLeft =
+                                                                                              RefinedE'
+                                                                                                ( TypeRefine'
+                                                                                                    { typeRefineName = Name' ("Nat" :| ["T"]) (),
+                                                                                                      typeRefineRefinement =
+                                                                                                        Application'
+                                                                                                          ( App'
+                                                                                                              { applicationName = Name' ("has-n" :| []) (),
+                                                                                                                applicationArgs =
+                                                                                                                  Name' ("stor" :| ["accounts"]) ()
+                                                                                                                    :| [ Name' ("from" :| []) (),
+                                                                                                                         Name' ("num" :| []) ()
+                                                                                                                       ],
+                                                                                                                annApp = ()
+                                                                                                              }
+                                                                                                          )
+                                                                                                          (),
+                                                                                                      annTypeRefine = ()
+                                                                                                    }
+                                                                                                )
+                                                                                                (),
+                                                                                            infixOp = "->" :| [],
+                                                                                            infixRight = Name' ("Token" :| ["Storage"]) (),
+                                                                                            annInf = ()
+                                                                                          }
+                                                                                      )
+                                                                                      (),
+                                                                                  annInf = ()
+                                                                                }
+                                                                            )
+                                                                            (),
+                                                                        annInf = ()
+                                                                      }
+                                                                  )
+                                                                  (),
+                                                              annInf = ()
+                                                            }
+                                                        )
+                                                        (),
+                                                    annInf = ()
+                                                  }
+                                              )
+                                              (),
+                                          annInf = ()
+                                        }
+                                    )
+                                    (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "transfer-stor",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "stor" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "add-from" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "add-to" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "num" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Let'
+                        ( Let'''
+                            { letBindings =
+                                Like'
+                                  { functionLikedName = "new-acc",
+                                    functionLikeArgs = [],
+                                    functionLikeBody =
+                                      Body'
+                                        ( Application'
+                                            ( App'
+                                                { applicationName =
+                                                    Name'
+                                                      ("account-add" :| [])
+                                                      (),
+                                                  applicationArgs =
+                                                    Parened'
+                                                      ( Application'
+                                                          ( App'
+                                                              { applicationName = Name' ("account-sub" :| []) (),
+                                                                applicationArgs =
+                                                                  Name' ("stor" :| ["accounts"]) ()
+                                                                    :| [Name' ("add-from" :| []) ()],
+                                                                annApp = ()
+                                                              }
+                                                          )
+                                                          ()
+                                                      )
+                                                      ()
+                                                      :| [Name' ("add-to" :| []) (), Name' ("num" :| []) ()],
+                                                  annApp = ()
+                                                }
+                                            )
+                                            ()
+                                        )
+                                        (),
+                                    annLike = ()
+                                  },
+                              letBody =
+                                ExpRecord'
+                                  ( ExpressionRecord'
+                                      { expRecordFields =
+                                          NonPunned' ("total-supply" :| []) (Name' ("stor" :| ["total-supply"]) ()) ()
+                                            :| [NonPunned' ("accounts" :| []) (Name' ("new-acc" :| []) ()) ()],
+                                        annExpressionRecord = ()
+                                      }
+                                  )
+                                  (),
+                              annLet'' = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Module'
+      ( Mod'
+          ( Like'
+              { functionLikedName = "Validation",
+                functionLikeArgs = [],
+                functionLikeBody =
+                  Body'
+                    ( Function'
+                        ( Func'
+                            ( Like'
+                                { functionLikedName = "T",
+                                  functionLikeArgs = [],
+                                  functionLikeBody =
+                                    Body'
+                                      ( Infix'
+                                          ( Inf'
+                                              { infixLeft = Name' ("Token" :| ["T"]) (),
+                                                infixOp = "->" :| [],
+                                                infixRight =
+                                                  Infix'
+                                                    ( Inf'
+                                                        { infixLeft = Name' ("Transaction" :| ["T"]) (),
+                                                          infixOp = "->" :| [],
+                                                          infixRight = Name' ("Bool" :| []) (),
+                                                          annInf = ()
+                                                        }
+                                                    )
+                                                    (),
+                                                annInf = ()
+                                              }
+                                          )
+                                          ()
+                                      )
+                                      (),
+                                  annLike = ()
+                                }
+                            )
+                            ()
+                        )
+                        ()
+                        :| [ Function'
+                               ( Func'
+                                   ( Like'
+                                       { functionLikedName = "mint",
+                                         functionLikeArgs =
+                                           [ ConcreteA'
+                                               (MatchLogic' {matchLogicContents = MatchName' "token" (), matchLogicNamed = Nothing, annMatchLogic = ()})
+                                               (),
+                                             ConcreteA'
+                                               ( MatchLogic'
+                                                   { matchLogicContents = MatchName' "tx" (),
+                                                     matchLogicNamed = Nothing,
+                                                     annMatchLogic = ()
+                                                   }
+                                               )
+                                               ()
+                                           ],
+                                         functionLikeBody =
+                                           Body'
+                                             ( Match'
+                                                 ( Match'''
+                                                     { matchOn = Name' ("tx" :| ["data"]) (),
+                                                       matchBindigns =
+                                                         MatchL'
+                                                           { matchLPattern =
+                                                               MatchLogic'
+                                                                 { matchLogicContents = MatchCon' ("Transaction" :| ["Mint"]) [] (),
+                                                                   matchLogicNamed = Nothing,
+                                                                   annMatchLogic = ()
+                                                                 },
+                                                             matchLBody =
+                                                               Infix'
+                                                                 ( Inf'
+                                                                     { infixLeft = Name' ("token" :| ["owner"]) (),
+                                                                       infixOp = "==" :| [],
+                                                                       infixRight = Name' ("tx" :| ["authorized-account"]) (),
+                                                                       annInf = ()
+                                                                     }
+                                                                 )
+                                                                 (),
+                                                             annMatchL = ()
+                                                           }
+                                                           :| [ MatchL'
+                                                                  { matchLPattern =
+                                                                      MatchLogic'
+                                                                        { matchLogicContents = MatchName' "_" (),
+                                                                          matchLogicNamed = Nothing,
+                                                                          annMatchLogic = ()
+                                                                        },
+                                                                    matchLBody = Name' ("false" :| []) (),
+                                                                    annMatchL = ()
+                                                                  }
+                                                              ],
+                                                       annMatch'' = ()
+                                                     }
+                                                 )
+                                                 ()
+                                             )
+                                             (),
+                                         annLike = ()
+                                       }
+                                   )
+                                   ()
+                               )
+                               (),
+                             Function'
+                               ( Func'
+                                   ( Like'
+                                       { functionLikedName = "transfer",
+                                         functionLikeArgs =
+                                           [ ConcreteA'
+                                               ( MatchLogic'
+                                                   { matchLogicContents = MatchName' "token" (),
+                                                     matchLogicNamed = Nothing,
+                                                     annMatchLogic = ()
+                                                   }
+                                               )
+                                               (),
+                                             ConcreteA'
+                                               ( MatchLogic'
+                                                   { matchLogicContents = MatchName' "tx" (),
+                                                     matchLogicNamed = Nothing,
+                                                     annMatchLogic = ()
+                                                   }
+                                               )
+                                               ()
+                                           ],
+                                         functionLikeBody =
+                                           Body'
+                                             ( Match'
+                                                 ( Match'''
+                                                     { matchOn = Name' ("tx" :| ["data"]) (),
+                                                       matchBindigns =
+                                                         MatchL'
+                                                           { matchLPattern =
+                                                               MatchLogic'
+                                                                 { matchLogicContents =
+                                                                     MatchCon'
+                                                                       ("Transaction" :| ["Transfer"])
+                                                                       [ MatchLogic'
+                                                                           { matchLogicContents =
+                                                                               MatchRecord'
+                                                                                 ( Punned'
+                                                                                     ("from-account" :| [])
+                                                                                     ()
+                                                                                     :| [Punned' ("amount" :| []) ()]
+                                                                                 )
+                                                                                 (),
+                                                                             matchLogicNamed = Nothing,
+                                                                             annMatchLogic = ()
+                                                                           }
+                                                                       ]
+                                                                       (),
+                                                                   matchLogicNamed = Nothing,
+                                                                   annMatchLogic = ()
+                                                                 },
+                                                             matchLBody =
+                                                               Infix'
+                                                                 ( Inf'
+                                                                     { infixLeft =
+                                                                         Application'
+                                                                           ( App'
+                                                                               { applicationName = Name' ("has-n" :| []) (),
+                                                                                 applicationArgs =
+                                                                                   Name' ("token" :| ["storage", "accounts"]) ()
+                                                                                     :| [ Name' ("from-account" :| []) (),
+                                                                                          Name' ("amount" :| []) ()
+                                                                                        ],
+                                                                                 annApp = ()
+                                                                               }
+                                                                           )
+                                                                           (),
+                                                                       infixOp = "&&" :| [],
+                                                                       infixRight =
+                                                                         Infix'
+                                                                           ( Inf'
+                                                                               { infixLeft = Name' ("tx" :| ["authorized-account"]) (),
+                                                                                 infixOp = "==" :| [],
+                                                                                 infixRight = Name' ("from-account" :| []) (),
+                                                                                 annInf = ()
+                                                                               }
+                                                                           )
+                                                                           (),
+                                                                       annInf = ()
+                                                                     }
+                                                                 )
+                                                                 (),
+                                                             annMatchL = ()
+                                                           }
+                                                           :| [ MatchL'
+                                                                  { matchLPattern =
+                                                                      MatchLogic'
+                                                                        { matchLogicContents = MatchName' "_" (),
+                                                                          matchLogicNamed = Nothing,
+                                                                          annMatchLogic = ()
+                                                                        },
+                                                                    matchLBody = Name' ("false" :| []) (),
+                                                                    annMatchL = ()
+                                                                  }
+                                                              ],
+                                                       annMatch'' = ()
+                                                     }
+                                                 )
+                                                 ()
+                                             )
+                                             (),
+                                         annLike = ()
+                                       }
+                                   )
+                                   ()
+                               )
+                               (),
+                             Function'
+                               ( Func'
+                                   ( Like'
+                                       { functionLikedName = "Burn",
+                                         functionLikeArgs =
+                                           [ ConcreteA' (MatchLogic' {matchLogicContents = MatchName' "token" (), matchLogicNamed = Nothing, annMatchLogic = ()}) (),
+                                             ConcreteA'
+                                               ( MatchLogic'
+                                                   { matchLogicContents = MatchName' "tx" (),
+                                                     matchLogicNamed = Nothing,
+                                                     annMatchLogic = ()
+                                                   }
+                                               )
+                                               ()
+                                           ],
+                                         functionLikeBody =
+                                           Body'
+                                             ( Match'
+                                                 ( Match'''
+                                                     { matchOn = Name' ("tx" :| ["data"]) (),
+                                                       matchBindigns =
+                                                         MatchL'
+                                                           { matchLPattern =
+                                                               MatchLogic'
+                                                                 { matchLogicContents =
+                                                                     MatchCon'
+                                                                       ("Transaction" :| ["Burn"])
+                                                                       [ MatchLogic'
+                                                                           { matchLogicContents =
+                                                                               MatchRecord'
+                                                                                 ( Punned'
+                                                                                     ("burn-from-account" :| [])
+                                                                                     ()
+                                                                                     :| [Punned' ("burn-amount" :| []) ()]
+                                                                                 )
+                                                                                 (),
+                                                                             matchLogicNamed = Nothing,
+                                                                             annMatchLogic = ()
+                                                                           }
+                                                                       ]
+                                                                       (),
+                                                                   matchLogicNamed = Nothing,
+                                                                   annMatchLogic = ()
+                                                                 },
+                                                             matchLBody =
+                                                               Infix'
+                                                                 ( Inf'
+                                                                     { infixLeft =
+                                                                         Application'
+                                                                           ( App'
+                                                                               { applicationName = Name' ("has-n" :| []) (),
+                                                                                 applicationArgs =
+                                                                                   Name' ("token" :| ["storage", "accounts"]) ()
+                                                                                     :| [ Name' ("burn-from-account" :| []) (),
+                                                                                          Name' ("burn-amount" :| []) ()
+                                                                                        ],
+                                                                                 annApp = ()
+                                                                               }
+                                                                           )
+                                                                           (),
+                                                                       infixOp = "&&" :| [],
+                                                                       infixRight =
+                                                                         Infix'
+                                                                           ( Inf'
+                                                                               { infixLeft = Name' ("tx" :| ["authorized-account"]) (),
+                                                                                 infixOp = "==" :| [],
+                                                                                 infixRight = Name' ("burn-from-account" :| []) (),
+                                                                                 annInf = ()
+                                                                               }
+                                                                           )
+                                                                           (),
+                                                                       annInf = ()
+                                                                     }
+                                                                 )
+                                                                 (),
+                                                             annMatchL = ()
+                                                           }
+                                                           :| [ MatchL'
+                                                                  { matchLPattern =
+                                                                      MatchLogic'
+                                                                        { matchLogicContents = MatchName' "_" (),
+                                                                          matchLogicNamed = Nothing,
+                                                                          annMatchLogic = ()
+                                                                        },
+                                                                    matchLBody = Name' ("false" :| []) (),
+                                                                    annMatchL = ()
+                                                                  }
+                                                              ],
+                                                       annMatch'' = ()
+                                                     }
+                                                 )
+                                                 ()
+                                             )
+                                             (),
+                                         annLike = ()
+                                       }
+                                   )
+                                   ()
+                               )
+                               ()
+                           ]
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      (),
+    Type'
+      ( Typ'
+          { typeUsage = Nothing,
+            typeName' = "Error",
+            typeArgs = [],
+            typeForm =
+              NonArrowed'
+                { dataAdt =
+                    Sum'
+                      ( S' {sumConstructor = "NotEnoughFunds", sumValue = Just (ADTLike' [] ()), annS = ()}
+                          :| [ S'
+                                 { sumConstructor = "NotSameAccount",
+                                   sumValue = Just (ADTLike' [] ()),
+                                   annS = ()
+                                 },
+                               S' {sumConstructor = "NotOwnerToken", sumValue = Just (ADTLike' [] ()), annS = ()},
+                               S' {sumConstructor = "NotEnoughTokens", sumValue = Just (ADTLike' [] ()), annS = ()}
+                             ]
+                      )
+                      (),
+                  annNonArrowed = ()
+                },
+            annTyp = ()
+          }
+      )
+      (),
+    Signature'
+      ( Sig'
+          { signatureName = "exec",
+            signatureUsage = Nothing,
+            signatureArrowType =
+              Infix'
+                ( Inf'
+                    { infixLeft = Name' ("Token" :| ["T"]) (),
+                      infixOp = "->" :| [],
+                      infixRight =
+                        Infix'
+                          ( Inf'
+                              { infixLeft = Name' ("Transaction" :| ["T"]) (),
+                                infixOp = "->" :| [],
+                                infixRight =
+                                  Application'
+                                    ( App'
+                                        { applicationName = Name' ("Either" :| ["T"]) (),
+                                          applicationArgs = Name' ("Error" :| []) () :| [Name' ("Token" :| ["T"]) ()],
+                                          annApp = ()
+                                        }
+                                    )
+                                    (),
+                                annInf = ()
+                              }
+                          )
+                          (),
+                      annInf = ()
+                    }
+                )
+                (),
+            signatureConstraints = [],
+            annSig = ()
+          }
+      )
+      (),
+    Function'
+      ( Func'
+          ( Like'
+              { functionLikedName = "exec",
+                functionLikeArgs =
+                  [ ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "token" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      (),
+                    ConcreteA'
+                      ( MatchLogic'
+                          { matchLogicContents = MatchName' "tx" (),
+                            matchLogicNamed = Nothing,
+                            annMatchLogic = ()
+                          }
+                      )
+                      ()
+                  ],
+                functionLikeBody =
+                  Body'
+                    ( Match'
+                        ( Match'''
+                            { matchOn = Name' ("tx" :| ["data"]) (),
+                              matchBindigns =
+                                MatchL'
+                                  { matchLPattern =
+                                      MatchLogic'
+                                        { matchLogicContents =
+                                            MatchCon'
+                                              ("Transfer" :| [])
+                                              [ MatchLogic'
+                                                  { matchLogicContents = MatchName' "_" (),
+                                                    matchLogicNamed = Nothing,
+                                                    annMatchLogic = ()
+                                                  }
+                                              ]
+                                              (),
+                                          matchLogicNamed = Nothing,
+                                          annMatchLogic = ()
+                                        },
+                                    matchLBody =
+                                      Cond'
+                                        ( C'
+                                            ( CondExpression'
+                                                { condLogicPred =
+                                                    Application'
+                                                      ( App'
+                                                          { applicationName = Name' ("Validation" :| ["transfer"]) (),
+                                                            applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()],
+                                                            annApp = ()
+                                                          }
+                                                      )
+                                                      (),
+                                                  condLogicBody =
+                                                    Application'
+                                                      ( App'
+                                                          { applicationName = Name' ("Right" :| []) (),
+                                                            applicationArgs =
+                                                              Parened'
+                                                                ( Application'
+                                                                    ( App'
+                                                                        { applicationName = Name' ("transfer" :| []) (),
+                                                                          applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()],
+                                                                          annApp = ()
+                                                                        }
+                                                                    )
+                                                                    ()
+                                                                )
+                                                                ()
+                                                                :| [],
+                                                            annApp = ()
+                                                          }
+                                                      )
+                                                      (),
+                                                  annCondExpression = ()
+                                                }
+                                                :| [ CondExpression'
+                                                       { condLogicPred = Name' ("else" :| []) (),
+                                                         condLogicBody =
+                                                           Application'
+                                                             ( App'
+                                                                 { applicationName = Name' ("Left" :| []) (),
+                                                                   applicationArgs = Name' ("NotEnoughFunds" :| []) () :| [],
+                                                                   annApp = ()
+                                                                 }
+                                                             )
+                                                             (),
+                                                         annCondExpression = ()
+                                                       }
+                                                   ]
+                                            )
+                                            ()
+                                        )
+                                        (),
+                                    annMatchL = ()
+                                  }
+                                  :| [ MatchL'
+                                         { matchLPattern =
+                                             MatchLogic'
+                                               { matchLogicContents =
+                                                   MatchCon'
+                                                     ("Mint" :| [])
+                                                     [ MatchLogic'
+                                                         { matchLogicContents = MatchName' "_" (),
+                                                           matchLogicNamed = Nothing,
+                                                           annMatchLogic = ()
+                                                         }
+                                                     ]
+                                                     (),
+                                                 matchLogicNamed = Nothing,
+                                                 annMatchLogic = ()
+                                               },
+                                           matchLBody =
+                                             Cond'
+                                               ( C'
+                                                   ( CondExpression'
+                                                       { condLogicPred =
+                                                           Application'
+                                                             ( App'
+                                                                 { applicationName = Name' ("Validation" :| ["mint"]) (),
+                                                                   applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()],
+                                                                   annApp = ()
+                                                                 }
+                                                             )
+                                                             (),
+                                                         condLogicBody =
+                                                           Application'
+                                                             ( App'
+                                                                 { applicationName = Name' ("Right" :| []) (),
+                                                                   applicationArgs =
+                                                                     Parened'
+                                                                       ( Application'
+                                                                           ( App'
+                                                                               { applicationName = Name' ("mint" :| []) (),
+                                                                                 applicationArgs = Name' ("token" :| []) () :| [Name' ("tx" :| []) ()],
+                                                                                 annApp = ()
+                                                                               }
+                                                                           )
+                                                                           ()
+                                                                       )
+                                                                       ()
+                                                                       :| [],
+                                                                   annApp = ()
+                                                                 }
+                                                             )
+                                                             (),
+                                                         annCondExpression = ()
+                                                       }
+                                                       :| [ CondExpression'
+                                                              { condLogicPred = Name' ("else" :| []) (),
+                                                                condLogicBody =
+                                                                  Application'
+                                                                    ( App'
+                                                                        { applicationName = Name' ("Left" :| []) (),
+                                                                          applicationArgs = Name' ("NotEnoughFunds" :| []) () :| [],
+                                                                          annApp = ()
+                                                                        }
+                                                                    )
+                                                                    (),
+                                                                annCondExpression = ()
+                                                              }
+                                                          ]
+                                                   )
+                                                   ()
+                                               )
+                                               (),
+                                           annMatchL = ()
+                                         }
+                                     ],
+                              annMatch'' = ()
+                            }
+                        )
+                        ()
+                    )
+                    (),
+                annLike = ()
+              }
+          )
+          ()
+      )
+      ()
+  ]


### PR DESCRIPTION
So far one term has striken out to me as wrong

```haskell
AST.MatchLogic (AST.MatchCon (NameSymbol.fromSymbol "M") []) Nothing
```

is ambigious and could be an argument.