### PR TITLE
Fixing bug where not special casing appM causes usage errors

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,9 +4,9 @@ import qualified Compile as Compile
 import qualified Config as Config
 import Development.GitRev
 import qualified Interactive as Interactive
+import Juvix.Library
 import Options
 import Options.Applicative
-import Juvix.Library
 import System.Directory
 import Text.PrettyPrint.ANSI.Leijen hiding ((<>))
 import Text.RawString.QQ

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -1,7 +1,7 @@
 module Options where
 
-import Options.Applicative
 import Juvix.Library hiding (option)
+import Options.Applicative
 
 data Context
   = Context

--- a/doc/Code/App.org
+++ b/doc/Code/App.org
@@ -25,7 +25,11 @@
   + [[Default]]
   + [[Library]]
 * Main
+- _Relies on_
+  + [[Library]]
 * Options
+- _Relies on_
+  + [[Library]]
 * Types
 - _Relies on_
   + [[Types]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -345,8 +345,6 @@ Serves as a module for various debugging functions
   + [[Library]]
 ** Michelson
 *** Setup <<Michelson/Setup>>
-*** app
-**** Main <<Michelson/app/Main>>
 *** src
 **** Juvix
 ***** Backends
@@ -1114,8 +1112,6 @@ Can be added to via core translation
   + [[Library]]
 * StandardLibrary
 ** Setup <<StandardLibrary/Setup>>
-** app
-*** Main <<StandardLibrary/app/Main>>
 ** src
 *** Juvix
 **** Library

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
@@ -55,7 +55,7 @@ compileToMichelsonContract term = do
       modify @"stack"
         ( VStack.cons
             ( VStack.VarE
-               (Set.singleton name)
+                (Set.singleton name)
                 (VStack.Usage argUsage VStack.notSaved)
                 Nothing,
               argTy

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
@@ -47,6 +47,7 @@ compileToMichelsonContract ::
   m (M.Contract' M.ExpandedOp, M.SomeContract)
 compileToMichelsonContract term = do
   let Ann.Ann _ ty _ = term
+      Ann.Pi argUsage _ _ = ty
   michelsonTy <- DSL.typeToPrimType ty
   case michelsonTy of
     M.Type (M.TLambda argTy@(M.Type (M.TPair _ _ paramTy storageTy) _) _) _ -> do
@@ -56,8 +57,8 @@ compileToMichelsonContract term = do
       modify @"stack"
         ( VStack.cons
             ( VStack.VarE
-                (Set.singleton name)
-                (VStack.Usage Omega VStack.notSaved)
+               (Set.singleton name)
+                (VStack.Usage argUsage VStack.notSaved)
                 Nothing,
               argTy
             )

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
@@ -47,12 +47,10 @@ compileToMichelsonContract ::
   m (M.Contract' M.ExpandedOp, M.SomeContract)
 compileToMichelsonContract term = do
   let Ann.Ann _ ty _ = term
-      Ann.Pi argUsage _ _ = ty
   michelsonTy <- DSL.typeToPrimType ty
   case michelsonTy of
     M.Type (M.TLambda argTy@(M.Type (M.TPair _ _ paramTy storageTy) _) _) _ -> do
-      -- TODO: Figure out what happened to argTy.
-      let Ann.Ann _ _ (Ann.LamM _ [name] body) = term
+      let Ann.Ann _ (Ann.Pi argUsage _ _) (Ann.LamM _ [name] body) = term
       let paramTy' = M.ParameterType paramTy (M.ann "")
       modify @"stack"
         ( VStack.cons
@@ -66,7 +64,7 @@ compileToMichelsonContract term = do
       _ <- DSL.instOuter body
       michelsonOp' <- mconcat |<< get @"ops"
       --
-      let michelsonOp = michelsonOp' <> DSL.dip [DSL.drop]
+      let michelsonOp = michelsonOp'
       --
       let contract = M.Contract paramTy' storageTy [michelsonOp]
       --

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/VirtualStack.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/VirtualStack.hs
@@ -291,20 +291,32 @@ unSave num (T stack i) = T (go num stack) i
     go _ [] = []
 
 addName :: Symbol -> Symbol -> T lamType -> T lamType
-addName toFind toAdd (T stack i) = T (f <$> stack) i
+addName = addNameSet . Set.singleton
+
+addNameSet :: Set Symbol -> Symbol -> T lamType -> T lamType
+addNameSet toFind toAdd (T stack i) = T (f <$> stack) i
   where
     f (VarE x i t, type')
-      | Set.member toFind x = (VarE (Set.insert toAdd x) i t, type')
+      | not $ null $ Set.intersection toFind x = (VarE (Set.insert toAdd x) i t, type')
     f t = t
 
 nameTop :: Symbol -> Usage.T -> T lamType -> T lamType
 nameTop sym usage t =
   case hd of
     (Val i, ty) -> cons (varEName sym (defUsage usage) (Just i), ty) rest
-    (VarE s u mb, ty) -> cons (VarE (Set.insert sym s) u mb, ty) rest
+    (VarE setOfNames _ _, _) ->
+      -- we must propagate the name to the other vars
+      -- there must be some intersection between the vars to be valid
+      -- so this should be enough to update all usages
+      addNameSet setOfNames sym t
   where
     hd = car t
     rest = cdr t
+
+
+peek :: T lamType -> Maybe (Elem lamType, T.Type)
+peek (T (s : _xs) _) = Just s
+peek (T [] _) = Nothing
 
 -- TODO ∷ properly progate changes with new model
 drop :: Int -> T lamType -> T lamType

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/VirtualStack.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/VirtualStack.hs
@@ -313,7 +313,6 @@ nameTop sym usage t =
     hd = car t
     rest = cdr t
 
-
 peek :: T lamType -> Maybe (Elem lamType, T.Type)
 peek (T (s : _xs) _) = Just s
 peek (T [] _) = Nothing

--- a/library/Backends/Michelson/test/Michelson.hs
+++ b/library/Backends/Michelson/test/Michelson.hs
@@ -532,7 +532,7 @@ xtwice =
               Ann one (primTy int) (J.Var "x")
             ]
       )
-      [push1Int 2, push1Int 3, push1Int 4]
+      [push1Int 2, pushInt (SNat 2) 3, push1Int 4]
 
 oddApp :: Term
 oddApp =
@@ -1028,8 +1028,24 @@ annIntOne :: Integer -> Term
 annIntOne i =
   Ann one (primTy Untyped.int) (J.Prim (Constant (M.ValueInt i)))
 
+pushInt :: Usage -> Integer -> AnnTerm PrimTy NewPrim
+pushInt usage i = pushUsage usage (M.ValueInt i) Untyped.int
+
 push1Int :: Integer -> AnnTerm PrimTy NewPrim
 push1Int i = push1 (M.ValueInt i) Untyped.int
+
+pushUsage :: Usage -> M.Value' Op -> M.Type -> AnnTerm PrimTy NewPrim
+pushUsage usage const ty =
+  Ann
+    usage
+    (primTy Untyped.unit)
+    $ J.AppM
+      ( Ann one (J.Pi usage (primTy ty) (primTy ty))
+          $ J.Prim
+          $ Instructions.toNewPrimErr
+          $ Instructions.push ty (M.ValueNil) -- the undefined here is never used
+      )
+      [Ann one (primTy ty) (J.Prim (Constant const))]
 
 push1 :: M.Value' Op -> M.Type -> AnnTerm PrimTy NewPrim
 push1 const ty =

--- a/library/Backends/Michelson/test/Michelson.hs
+++ b/library/Backends/Michelson/test/Michelson.hs
@@ -615,11 +615,11 @@ primLam (ty :| (t : ts)) = J.Pi one (J.PrimTy (PrimTy ty)) (primLam (t :| ts))
 
 identityAppTerm :: Term
 identityAppTerm =
-  Ann one identityType
+  Ann one identityType2
     $ J.LamM [] ["y"]
     $ Ann one (primTy (Untyped.pair opl Untyped.unit))
     $ J.AppM
-      ( Ann one identityType
+      ( Ann one identityType2
           $ J.LamM [] ["x"]
           $ Ann one (primTy (Untyped.pair opl Untyped.unit))
           $ J.AppM

--- a/library/Backends/Michelson/test/Michelson.hs
+++ b/library/Backends/Michelson/test/Michelson.hs
@@ -615,11 +615,11 @@ primLam (ty :| (t : ts)) = J.Pi one (J.PrimTy (PrimTy ty)) (primLam (t :| ts))
 
 identityAppTerm :: Term
 identityAppTerm =
-  Ann one identityType2
+  Ann one identityType
     $ J.LamM [] ["y"]
     $ Ann one (primTy (Untyped.pair opl Untyped.unit))
     $ J.AppM
-      ( Ann one identityType2
+      ( Ann one identityType
           $ J.LamM [] ["x"]
           $ Ann one (primTy (Untyped.pair opl Untyped.unit))
           $ J.AppM
@@ -636,11 +636,11 @@ identityAppTerm =
 
 identityAppExpr :: Term
 identityAppExpr =
-  Ann one identityType2
+  Ann one identityType
     $ J.LamM [] ["y"]
     $ Ann one (primTy (Untyped.pair unitl Untyped.unit))
     $ J.AppM
-      ( Ann one identityType2
+      ( Ann one identityType
           $ J.LamM [] ["x"]
           $ Ann one (primTy (Untyped.pair unitl Untyped.unit))
           $ J.AppM
@@ -705,7 +705,7 @@ identityAppExpr2 :: Term
 identityAppExpr2 =
   Ann
     one
-    identityType2
+    identityType
     $ J.LamM [] ["x"]
     $ Ann one (primTy (Untyped.pair opl Untyped.unit))
     $ J.AppM
@@ -963,10 +963,6 @@ pairTy = primPairTy
 
 identityType :: Type
 identityType =
-  J.Pi Omega (primTy unitPair) (primTy (Untyped.pair opl unit))
-
-identityType2 :: Type
-identityType2 =
   J.Pi one (primTy unitPair) (primTy (Untyped.pair opl unit))
 
 unitl :: M.Type

--- a/library/Backends/Michelson/test/Michelson.hs
+++ b/library/Backends/Michelson/test/Michelson.hs
@@ -150,7 +150,7 @@ identityApp2 =
   shouldCompile
     identityAppTerm2
     identityType
-    "parameter unit;storage unit;code { { DIG 0;DUP;DUG 1;CAR;DIG 0;NIL operation;PAIR;DIP { DROP } } };"
+    "parameter unit;storage unit;code { { DIG 0;CAR;DIG 0;NIL operation;PAIR } };"
 
 unitTest :: T.TestTree
 unitTest =
@@ -161,14 +161,14 @@ identityFn =
   shouldCompile
     identityTerm
     identityType
-    "parameter unit;storage unit;code { { DIG 0;DUP;DUG 1;CAR;NIL operation;PAIR;DIP { DROP } } };"
+    "parameter unit;storage unit;code { { DIG 0;CAR;NIL operation;PAIR } };"
 
 identityApp :: T.TestTree
 identityApp =
   shouldCompile
     identityAppTerm
     identityType
-    "parameter unit;storage unit;code { { DIG 0;DUP;DUG 1;DIG 0;DUP;DUG 1;CAR;NIL operation;PAIR;DIP 1 { DROP };DIP { DROP } } };"
+    "parameter unit;storage unit;code { { DIG 0;DIG 0;CAR;NIL operation;PAIR } };"
 
 underExactConstTest :: T.TestTree
 underExactConstTest = interpretExpression underExactConst M.ValueUnit
@@ -941,11 +941,10 @@ identityTermAns =
           )
           (M.Type (TPair "" "" (M.Type TUnit "") (M.Type TUnit "")) "")
           [ SeqEx [],
-            SeqEx [PrimEx (DIG 0), PrimEx (DUP ""), PrimEx (DUG 1)],
+            PrimEx (DIG 0),
             PrimEx (CAR "" ""),
             PrimEx (NIL "" "" (M.Type TOperation "")),
-            PrimEx (PAIR "" "" "" ""),
-            PrimEx (DIPN 1 [PrimEx DROP])
+            PrimEx (PAIR "" "" "" "")
           ]
       )
   ]


### PR DESCRIPTION
It seems the errors in #537 are related to names not propogating propelry...

However fixing this breaks the identity example @cwgoes 

```haskell
identityApp :: T.TestTree
identityApp =
  shouldCompile
    identityAppTerm
    identityType
    "parameter unit;storage unit;code { { DIG 0;DUP;DUG 1;DIG 0;DUP;DUG 1;CAR;NIL operation;PAIR;DIP 1 { DROP };DIP { DROP } } };"


   but got: Left (DidNotTypecheck (SeqEx [PrimEx DIG 0,PrimEx DUP,PrimEx DUG 1,PrimEx DIG 0,PrimEx DUP,PrimEx DUG 1,PrimEx CAR,PrimEx NIL operation,PrimEx PAIR,PrimEx DIP 2 { DROP },PrimEx DIP 1 { DROP },PrimEx DIP { DROP }]) Error checking expression DROP against input stack type [].)

```
