### PR TITLE
Some minor makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ test:
 	stack test --copy-bins --fast --jobs=$(shell nproc) --test-arguments "--hide-successes --ansi-tricks false"
 
 test-parser: build
-	ls test/examples/demo | xargs -t -n 1 -I % juvix parse test/examples/demo/%
+	ls test/examples/demo | xargs -t -n 1 -I % stack exec juvix parse test/examples/demo/%
 
 test-typecheck: build
-	ls test/examples/demo | xargs -t -n 1 -I % juvix typecheck test/examples/demo/%
+	ls test/examples/demo | xargs -t -n 1 -I % stack exec juvix typecheck test/examples/demo/%
 
 test-compile: build
-	ls test/examples/demo | xargs -n 1 -I % basename % .ju | xargs -t -n 1 -I % juvix compile test/examples/demo/%.ju test/examples/demo/%.tz
+	ls test/examples/demo | xargs -n 1 -I % basename % .ju | xargs -t -n 1 -I % stack exec juvix compile test/examples/demo/%.ju test/examples/demo/%.tz
 
 bench:
 	stack bench --benchmark-arguments="--output ./doc/Code/bench.html"

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,13 @@ org-gen:
 test:
 	stack test --copy-bins --fast --jobs=$(shell nproc) --test-arguments "--hide-successes --ansi-tricks false"
 
-test-parser:
+test-parser: build
 	ls test/examples/demo | xargs -t -n 1 -I % juvix parse test/examples/demo/%
 
-test-typecheck:
+test-typecheck: build
 	ls test/examples/demo | xargs -t -n 1 -I % juvix typecheck test/examples/demo/%
 
-test-compile:
+test-compile: build
 	ls test/examples/demo | xargs -n 1 -I % basename % .ju | xargs -t -n 1 -I % juvix compile test/examples/demo/%.ju test/examples/demo/%.tz
 
 bench:


### PR DESCRIPTION
- Make the `test-*` targets depend on `build`, so they are actually testing the current code
- Use `stack exec juvix` instead of just `juvix`, so the executable need not be installed globally