### PR TITLE
Makefile: Don't copy executable to global path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ build-z3:
 	cd z3/build && make install
 
 build:
-	stack build --copy-bins --fast --jobs $(shell nproc)
+	stack build --fast --jobs $(shell nproc)
 
 build-watch:
-	stack build --copy-bins --fast --file-watch
+	stack build --fast --file-watch
 
 build-prod: clean
-	stack build --copy-bins --jobs $(shell nproc) --ghc-options "-O3 -fllvm" --flag juvix:incomplete-error
+	stack build --jobs $(shell nproc) --ghc-options "-O3 -fllvm" --flag juvix:incomplete-error
 
 build-format:
 	stack install ormolu
@@ -37,7 +37,7 @@ org-gen:
 	org-generation app/ doc/Code/App.org test/ doc/Code/Test.org src/ doc/Code/Juvix.org bench/ doc/Code/Bench.org library/ doc/Code/Library.org
 
 test:
-	stack test --copy-bins --fast --jobs=$(shell nproc) --test-arguments "--hide-successes --ansi-tricks false"
+	stack test --fast --jobs=$(shell nproc) --test-arguments "--hide-successes --ansi-tricks false"
 
 test-parser: build
 	ls test/examples/demo | xargs -t -n 1 -I % stack exec juvix parse test/examples/demo/%


### PR DESCRIPTION
This patch just removes the `--copy-bins` flags from the builds, since `stack exec` uses the local copy anyway.