### PR TITLE
Fix some typos in michelson parameterisation

### DIFF
--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -220,7 +220,7 @@ builtinTypes =
     ("Michelson.int", Untyped.TInt),
     ("Michelson.nat", Untyped.TNat),
     ("Michelson.string", Untyped.TString),
-    ("Michelson.string", Untyped.TBytes),
+    ("Michelson.bytes", Untyped.TBytes),
     ("Michelson.mutez", Untyped.TMutez),
     ("Michelson.bool", Untyped.TBool),
     ("Michelson.key-hash", Untyped.TKeyHash),
@@ -270,7 +270,7 @@ builtinValues =
     ("Michelson.self", Inst (M.SELF "" "")),
     ("Michelson.unit", Inst (M.UNIT "" "")),
     -- added symbols to not take values
-    ("Michelson.if", Inst (M.IF [] []))
+    ("Michelson.if_builtin", Inst (M.IF [] []))
   ]
     |> fmap (first NameSymbol.fromSymbol)
     |> Map.fromList


### PR DESCRIPTION
- `bytes` was called `string`
- `if` is a reserved word so it is renamed to `if_builtin` like in `Michelson.ju`