### PR TITLE
added a proper handleInfix function that properly preserves infix syms

### DIFF
--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -886,20 +886,17 @@ Tests that weak works as expected
   + [[Frontend/Types]]
   + [[Library]]
   + [[NameSymbol]]
-***** Lexer
-- _Relies on_
-  + [[Library]]
 ***** Parser <<Frontend/Parser>>
 - The front end parser for the Juvix Programming language
 - Parsers with S at the end, eat the spaces at the end of the parse
 - Parsers with SN at the end, eats the spaces and new lines at the
   end of the parse
 - _Relies on_
-  + [[Lexer]]
   + [[Frontend/Types]]
   + [[Frontend/Types/Base]]
   + [[Library]]
   + [[NameSymbol]]
+  + [[Lexer]]
 ***** Types <<Frontend/Types>>
 - This file defines the main ADT for the Juvix front end language.
 - This ADT corresponds to the bnf laid out [[https://github.com/cryptiumlabs/juvix/blob/develop/doc/Frontend/syntax.org][here]].
@@ -1234,8 +1231,13 @@ Can be added to via core translation
 ***** NameSymbol
 - _Relies on_
   + [[Library]]
+  + [[Lexer]]
 ***** PrettyPrint
 ***** Usage
+- _Relies on_
+  + [[Library]]
+***** Symbol
+****** Lexer
 - _Relies on_
   + [[Library]]
 ** test

--- a/library/Frontend/src/Juvix/Frontend/Parser.hs
+++ b/library/Frontend/src/Juvix/Frontend/Parser.hs
@@ -17,7 +17,6 @@ import qualified Data.ByteString.Char8 as Char8
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as Encoding
-import qualified Juvix.Frontend.Lexer as Lexer
 import qualified Juvix.Frontend.Types as Types
 import qualified Juvix.Frontend.Types.Base as Types
 import Juvix.Library hiding
@@ -33,6 +32,7 @@ import Juvix.Library hiding
     try,
   )
 import qualified Juvix.Library.NameSymbol as NameSymbol
+import qualified Juvix.Library.Symbol.Lexer as Lexer
 import Prelude (String, fail)
 
 --------------------------------------------------------------------------------

--- a/library/StandardLibrary/src/Juvix/Library/NameSymbol.hs
+++ b/library/StandardLibrary/src/Juvix/Library/NameSymbol.hs
@@ -8,6 +8,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Data.String (IsString (..))
 import qualified Data.Text as Text
 import Juvix.Library
+import qualified Juvix.Library.Symbol.Lexer as Lexer
 import qualified Prelude (foldr1)
 
 type T = NonEmpty Symbol
@@ -22,10 +23,39 @@ toSymbol =
 
 fromSymbol :: Symbol -> T
 fromSymbol =
-  NonEmpty.fromList . fmap internText . Text.splitOn "." . textify
+  NonEmpty.fromList . fmap internText . handleInfix . Text.splitOn "." . textify
 
 fromText :: Text -> T
 fromText = fromSymbol . internText
+
+-- TODO ∷ make this a fold!?
+handleInfix :: [Text] -> [Text]
+handleInfix [] = []
+handleInfix (x : xs) = rec' (x : xs) ""
+  where
+    rec' ("" : xs) currentInfixSymbol =
+      rec' xs (Text.snoc currentInfixSymbol '.')
+    rec' (x : xs) build
+      -- case 1)
+      | Lexer.validInfixSymbol (Lexer.charToWord8 (Text.head x)) =
+        rec' xs (build <> Text.cons '.' x)
+      | Text.null build =
+        x : rec' xs build
+      | otherwise =
+        -- case 3)
+        -- we must tail x, as we add an extra .
+        -- at the start of every infix symbol.
+        -- we do this because even a symbol like
+        -- "-" triggers case 1) which adds a '.'
+        -- to the front even when it shouldn't!
+        -- this is the correct behavior IFF we
+        -- are in the middle of a infix symbol!
+        build : Text.tail x : xs
+    rec' [] "" =
+      []
+    rec' [] acc =
+      -- see case 3)
+      [Text.tail acc]
 
 instance IsString T where
   fromString = fromSymbol . intern

--- a/library/StandardLibrary/src/Juvix/Library/NameSymbol.hs
+++ b/library/StandardLibrary/src/Juvix/Library/NameSymbol.hs
@@ -50,7 +50,7 @@ handleInfix (x : xs) = rec' (x : xs) ""
         -- to the front even when it shouldn't!
         -- this is the correct behavior IFF we
         -- are in the middle of a infix symbol!
-        build : Text.tail x : xs
+        Text.tail build : x : xs
     rec' [] "" =
       []
     rec' [] acc =

--- a/library/StandardLibrary/src/Juvix/Library/Symbol/Lexer.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Symbol/Lexer.hs
@@ -1,4 +1,4 @@
-module Juvix.Frontend.Lexer where
+module Juvix.Library.Symbol.Lexer where
 
 import qualified GHC.Unicode as Unicode
 import Juvix.Library hiding (div, maybe, option, takeWhile)

--- a/library/StandardLibrary/test/NameSymb.hs
+++ b/library/StandardLibrary/test/NameSymb.hs
@@ -3,6 +3,7 @@ module NameSymb where
 import Juvix.Library
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
 import qualified Test.Tasty.QuickCheck as T
 
 --------------------------------------------------------------------------------
@@ -13,14 +14,17 @@ top :: T.TestTree
 top =
   T.testGroup
     "NameSymbol tests:"
-    [idIsId]
+    [idIsId, infixSymbolCase]
 
 --------------------------------------------------------------------------------
 -- Functions
 --------------------------------------------------------------------------------
 
-id :: Symbol -> Symbol
-id = NameSymbol.toSymbol . NameSymbol.fromSymbol
+idL :: Symbol -> Symbol
+idL = NameSymbol.toSymbol . NameSymbol.fromSymbol
+
+idR :: NameSymbol.T -> NameSymbol.T
+idR = NameSymbol.fromSymbol . NameSymbol.toSymbol
 
 --------------------------------------------------------------------------------
 -- Tests
@@ -31,15 +35,26 @@ idIsId =
   T.forAll (T.listOf T.arbitraryUnicodeChar) (appenDot . intern)
     |> T.testProperty "toSymbol and fromSymbol are inverses"
 
+------------------
+-- IdL subset
+------------------
+
+infixSymbolCase :: T.TestTree
+infixSymbolCase =
+  let str = "Foo.Bar._Foo_-_.-..->.Bar.(Foo)...-..>.."
+   in T.testCase
+        "infix functions are properly reserved"
+        (idL str T.@=? str)
+
 --------------------------------------------------------------------------------
 -- property Helpers
 --------------------------------------------------------------------------------
 
 appenDot :: Symbol -> T.Property
 appenDot symb =
-  eq symb T..&&. eq dotEnd T..&&. eq dotStart T..&&. eq dotMiddle
+  eq symb T..&&. eq dotEnd T..&&. eq dotMiddle T..&&. eq dotStart
   where
-    eq s = id s T.=== s
+    eq s = idL s T.=== s
     --
     dotEnd = symb <> "."
     dotStart = "." <> symb


### PR DESCRIPTION
Tests to come.

With this, we satisfy the other way of the identiy


```haskell
id :: NameSymbol.T -> NameSymbol.T
id = NameSymbol.fromSymbol . NameSymbol.toSymbol
``` 

Fixes #608
