### PR TITLE
Add variables as arguments for primitives

### DIFF
--- a/app/Compile.hs
+++ b/app/Compile.hs
@@ -26,7 +26,7 @@ parse fin = do
       exitFailure
 
 typecheck ::
-  FilePath -> Backend -> IO (ErasedAnn.AnnTerm Param.PrimTy Param.PrimVal)
+  FilePath -> Backend -> IO (ErasedAnn.AnnTerm Param.PrimTy Param.PrimValHR)
 typecheck fin Michelson = do
   ctx <- parse fin
   let res = Pipeline.contextToCore ctx Param.michelson
@@ -41,7 +41,7 @@ typecheck fin Michelson = do
 typecheck _ _ = exitFailure
 
 typecheck' ::
-  FilePath -> Backend -> IO (ErasedAnn.AnnTerm Param.PrimTy Param.PrimVal)
+  FilePath -> Backend -> IO (ErasedAnn.AnnTerm Param.PrimTy Param.PrimValHR)
 typecheck' _ _ = do
   -- These terms are fake for now.
   let usage :: Usage.T

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -1,7 +1,7 @@
 module Types where
 
-import qualified Juvix.Core.Erasure.Types as Erasure
 import qualified Juvix.Core.ErasedAnn.Types as ErasedAnn
+import qualified Juvix.Core.Erasure.Types as Erasure
 import qualified Juvix.Core.IR.Typechecker.Types as Typed
 import qualified Juvix.Core.Types as Core
 import Juvix.Library hiding (log)

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -1,6 +1,7 @@
 module Types where
 
 import qualified Juvix.Core.Erasure.Types as Erasure
+import qualified Juvix.Core.ErasedAnn.Types as ErasedAnn
 import qualified Juvix.Core.IR.Typechecker.Types as Typed
 import qualified Juvix.Core.Types as Core
 import Juvix.Library hiding (log)
@@ -10,7 +11,7 @@ type Exec primTy primVal compErr =
   IO
     ( Either
         (Core.PipelineError primTy primVal compErr)
-        (Erasure.TermT primTy primVal),
+        (Erasure.Term primTy (ErasedAnn.TypedPrim primTy primVal)),
       [Core.PipelineLog primTy primVal]
     )
 

--- a/doc/Code/App.org
+++ b/doc/Code/App.org
@@ -29,4 +29,5 @@
   + [[Types]]
   + [[Types]]
   + [[Types]]
+  + [[Types]]
   + [[Library]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -384,6 +384,7 @@ This module provides a default contract environment
   + [[Instructions]]
   + [[InstructionsEff]]
   + [[Interpret]]
+  + [[Application]]
   + [[Prim]]
   + [[ErasedAnn/Types]]
   + [[Core/Parameterisation]]
@@ -406,6 +407,7 @@ This module provides a default contract environment
 - _Relies on_
   + [[Application]]
   + [[ErasedAnn/Types]]
+  + [[IR/Types]]
   + [[Core/Parameterisation]]
   + [[Library]]
   + [[NameSymbol]]
@@ -518,11 +520,13 @@ This module provides a default contract environment
 ***** Application
 Types to support partial application and polymorphic primitives.
 - _Relies on_
+  + [[IR/Types]]
   + [[Library]]
   + [[Usage]]
 ***** Parameterisation <<Core/Parameterisation>>
 - _Relies on_
   + [[Application]]
+  + [[IR/Types]]
   + [[Library]]
   + [[HashMap]]
   + [[NameSymbol]]
@@ -635,7 +639,9 @@ Types to support partial application and polymorphic primitives.
   + [[Usage]]
 ****** Types <<ErasedAnn/Types>>
 - _Relies on_
+  + [[Application]]
   + [[IR/Types]]
+  + [[Core/Parameterisation]]
   + [[Library]]
   + [[NameSymbol]]
   + [[Usage]]
@@ -657,8 +663,8 @@ Types to support partial application and polymorphic primitives.
   + [[Erased/Types]]
   + [[Erased/Types]]
   + [[Erased/Types/Base]]
-  + [[IR/Typechecker]]
   + [[Typechecker/Types]]
+  + [[IR/Types]]
   + [[IR/Types]]
   + [[Core/Parameterisation]]
   + [[Library]]

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
@@ -101,15 +101,20 @@ type Return = App.Return (P.PrimType PrimTy) RawPrimVal
 
 type Take = App.Take (P.PrimType PrimTy) RawPrimVal
 
+type Arg = App.Arg (P.PrimType PrimTy) RawPrimVal
+
 type PrimVal = Return
 
-toTake1 :: PrimVal -> Maybe Take
-toTake1 App.Cont {} = Nothing
-toTake1 App.Return {retType, retTerm} = Just fun
-  where
-    fun = App.Take {usage = Usage.Omega, type' = retType, term = retTerm}
+toArg :: PrimVal -> Maybe Arg
+toArg App.Cont {} = Nothing
+toArg App.Return {retType, retTerm} =
+  Just $ App.Take {
+    usage = Usage.Omega,
+    type' = retType,
+    term = App.TermArg retTerm
+  }
 
-toTakes :: PrimVal -> (Take, [Take], Natural)
+toTakes :: PrimVal -> (Take, [Arg], Natural)
 toTakes App.Cont {fun, args, numLeft} = (fun, args, numLeft)
 toTakes App.Return {retType, retTerm} = (fun, [], 0)
   where

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
@@ -99,27 +99,34 @@ type NewPrim = RawPrimVal
 {-# DEPRECATED NewPrim "use RawPrimVal" #-}
 
 type Return' ext = App.Return' ext (P.PrimType PrimTy) RawPrimVal
+
 type ReturnIR = Return' IR.NoExt
+
 type ReturnHR = Return' CoreErased.T
 
 type Take = App.Take (P.PrimType PrimTy) RawPrimVal
 
 type Arg' ext = App.Arg' ext (P.PrimType PrimTy) RawPrimVal
+
 type ArgIR = Arg' IR.NoExt
+
 type ArgHR = Arg' CoreErased.T
 
 type PrimVal' ext = Return' ext
+
 type PrimValIR = PrimVal' IR.NoExt
+
 type PrimValHR = PrimVal' CoreErased.T
 
 toArg :: PrimVal' ext -> Maybe (Arg' ext)
 toArg App.Cont {} = Nothing
 toArg App.Return {retType, retTerm} =
-  Just $ App.Take {
-    usage = Usage.Omega,
-    type' = retType,
-    term = App.TermArg retTerm
-  }
+  Just $
+    App.Take
+      { usage = Usage.Omega,
+        type' = retType,
+        term = App.TermArg retTerm
+      }
 
 toTakes :: PrimVal' ext -> (Take, [Arg' ext], Natural)
 toTakes App.Cont {fun, args, numLeft} = (fun, args, numLeft)

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
@@ -97,11 +97,11 @@ type NewPrim = RawPrimVal
 
 {-# DEPRECATED NewPrim "use RawPrimVal" #-}
 
-type Return = App.Return (P.PrimType PrimTy) RawPrimVal
+type Return = App.Return' CoreErased.T (P.PrimType PrimTy) RawPrimVal
 
 type Take = App.Take (P.PrimType PrimTy) RawPrimVal
 
-type Arg = App.Arg (P.PrimType PrimTy) RawPrimVal
+type Arg = App.Arg' CoreErased.T (P.PrimType PrimTy) RawPrimVal
 
 type PrimVal = Return
 

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
@@ -8,6 +8,7 @@ where
 
 import qualified Juvix.Core.Application as App
 import qualified Juvix.Core.ErasedAnn.Types as CoreErased
+import qualified Juvix.Core.IR.Types as IR
 import qualified Juvix.Core.Parameterisation as P
 import Juvix.Library hiding (Type)
 import qualified Juvix.Library.NameSymbol as NameSymbol
@@ -97,15 +98,21 @@ type NewPrim = RawPrimVal
 
 {-# DEPRECATED NewPrim "use RawPrimVal" #-}
 
-type Return = App.Return' CoreErased.T (P.PrimType PrimTy) RawPrimVal
+type Return' ext = App.Return' ext (P.PrimType PrimTy) RawPrimVal
+type ReturnIR = Return' IR.NoExt
+type ReturnHR = Return' CoreErased.T
 
 type Take = App.Take (P.PrimType PrimTy) RawPrimVal
 
-type Arg = App.Arg' CoreErased.T (P.PrimType PrimTy) RawPrimVal
+type Arg' ext = App.Arg' ext (P.PrimType PrimTy) RawPrimVal
+type ArgIR = Arg' IR.NoExt
+type ArgHR = Arg' CoreErased.T
 
-type PrimVal = Return
+type PrimVal' ext = Return' ext
+type PrimValIR = PrimVal' IR.NoExt
+type PrimValHR = PrimVal' CoreErased.T
 
-toArg :: PrimVal -> Maybe Arg
+toArg :: PrimVal' ext -> Maybe (Arg' ext)
 toArg App.Cont {} = Nothing
 toArg App.Return {retType, retTerm} =
   Just $ App.Take {
@@ -114,18 +121,18 @@ toArg App.Return {retType, retTerm} =
     term = App.TermArg retTerm
   }
 
-toTakes :: PrimVal -> (Take, [Arg], Natural)
+toTakes :: PrimVal' ext -> (Take, [Arg' ext], Natural)
 toTakes App.Cont {fun, args, numLeft} = (fun, args, numLeft)
 toTakes App.Return {retType, retTerm} = (fun, [], 0)
   where
     fun = App.Take {usage = Usage.Omega, type' = retType, term = retTerm}
 
-fromReturn :: Return -> PrimVal
+fromReturn :: Return' ext -> PrimVal' ext
 fromReturn = identity
 
 type RawTerm = CoreErased.AnnTerm PrimTy RawPrimVal
 
-type Term = CoreErased.AnnTerm PrimTy PrimVal
+type Term = CoreErased.AnnTerm PrimTy PrimValHR
 
 type NewTerm = RawTerm
 

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -96,11 +96,11 @@ arityRaw (Constant _) = 0
 arityRaw prim = Run.instructionOf prim |> Instructions.toNewPrimErr |> arityRaw
 
 data ApplyError
-  = PipelineError (Core.PipelineError PrimTy RawPrimVal CompilationError)
+  = CompilationError CompilationError
   | ReturnTypeNotPrimitive (ErasedAnn.Type PrimTy)
 
 instance Show ApplyError where
-  show (PipelineError perr) = Prelude.show perr
+  show (CompilationError perr) = Prelude.show perr
   show (ReturnTypeNotPrimitive ty) =
     "not a primitive type:\n\t" <> Prelude.show ty
 
@@ -148,7 +148,7 @@ applyProper fun args =
     Right x -> do
       retType <- toPrimType $ ErasedAnn.type' newTerm
       pure $ Prim.Return {retType, retTerm = Constant x}
-    Left err -> Left $ Core.Extra $ PipelineError $ Core.PrimError err
+    Left err -> Left $ Core.Extra $ CompilationError err
   where
     fun' = takeToTerm fun
     args' = takeToTerm <$> toList args

--- a/library/Core/src/Juvix/Core/Application.hs
+++ b/library/Core/src/Juvix/Core/Application.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE DeriveTraversable #-}
 -- |
 -- Types to support partial application and polymorphic primitives.
 module Juvix.Core.Application where
 
 import Juvix.Library
 import qualified Juvix.Library.Usage as Usage
+import qualified Juvix.Core.IR.Types as IR
+import Data.Bifunctor
+import Data.Bifoldable
+import Data.Bitraversable
 
 -- |
 -- A primitive along with its type, and possibly some arguments.
@@ -13,7 +18,7 @@ data Return ty term
       { -- | head of application
         fun :: Take ty term,
         -- | arguments
-        args :: [Take ty term],
+        args :: [Arg ty term],
         -- | number of arguments still expected
         numLeft :: Natural
       }
@@ -22,7 +27,33 @@ data Return ty term
       { retType :: ty,
         retTerm :: term
       }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+instance Bifunctor Return where
+  bimap = bimapDefault
+
+instance Bifoldable Return where
+  bifoldMap = bifoldMapDefault
+
+instance Bitraversable Return where
+  bitraverse f g = \case
+    Cont s ts n ->
+      Cont <$> bitraverse f g s
+           <*> traverse (bitraverse f (traverse g)) ts
+           <*> pure n
+    Return a s ->
+      Return <$> f a <*> g s
+
+
+data Arg' term
+  = BoundArg IR.BoundVar
+  | FreeArg  IR.GlobalName
+  | TermArg  term
+  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+argToTerm :: Alternative f => Arg' term -> f term
+argToTerm (TermArg t) = pure t
+argToTerm _ = empty
 
 -- |
 -- An argument to a partially applied primitive, which must be
@@ -33,4 +64,15 @@ data Take ty term
         type' :: ty,
         term :: term
       }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+instance Bifunctor Take where
+  bimap = bimapDefault
+
+instance Bifoldable Take where
+  bifoldMap = bifoldMapDefault
+
+instance Bitraversable Take where
+  bitraverse f g (Take π a s) = Take π <$> f a <*> g s
+
+type Arg ty term = Take ty (Arg' term)

--- a/library/Core/src/Juvix/Core/Application.hs
+++ b/library/Core/src/Juvix/Core/Application.hs
@@ -1,13 +1,15 @@
-{-# LANGUAGE DeriveTraversable, UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 -- |
 -- Types to support partial application and polymorphic primitives.
 module Juvix.Core.Application where
 
-import Juvix.Library
-import qualified Juvix.Library.Usage as Usage
-import qualified Juvix.Core.IR.Types as IR
 import Data.Bifoldable
 import Data.Bitraversable
+import qualified Juvix.Core.IR.Types as IR
+import Juvix.Library
+import qualified Juvix.Library.Usage as Usage
 
 -- |
 -- A primitive along with its type, and possibly some arguments.
@@ -28,9 +30,12 @@ data Return' ext ty term
       }
   deriving (Generic, Functor, Foldable, Traversable)
 
-deriving instance (Show (ParamVar ext), Show ty, Show term) =>
+deriving instance
+  (Show (ParamVar ext), Show ty, Show term) =>
   Show (Return' ext ty term)
-deriving instance (Eq (ParamVar ext), Eq ty, Eq term) =>
+
+deriving instance
+  (Eq (ParamVar ext), Eq ty, Eq term) =>
   Eq (Return' ext ty term)
 
 instance Bifunctor (Return' ext) where
@@ -43,20 +48,19 @@ instance Bitraversable (Return' ext) where
   bitraverse f g = \case
     Cont s ts n ->
       Cont <$> bitraverse f g s
-           <*> traverse (bitraverse f (traverse g)) ts
-           <*> pure n
+        <*> traverse (bitraverse f (traverse g)) ts
+        <*> pure n
     Return a s ->
       Return <$> f a <*> g s
 
 type Return = Return' IR.NoExt
-
 
 -- | The representation of variables used in IR.Term' ext
 type family ParamVar ext :: Type
 
 data DeBruijn
   = BoundVar IR.BoundVar
-  | FreeVar  IR.GlobalName
+  | FreeVar IR.GlobalName
   deriving (Show, Eq, Generic)
 
 type instance ParamVar IR.NoExt = DeBruijn
@@ -75,6 +79,7 @@ pattern FreeArg ::
 pattern FreeArg x = VarArg (FreeVar x)
 
 deriving instance (Show (ParamVar ext), Show term) => Show (ArgBody' ext term)
+
 deriving instance (Eq (ParamVar ext), Eq term) => Eq (ArgBody' ext term)
 
 type ArgBody = ArgBody' IR.NoExt

--- a/library/Core/src/Juvix/Core/ErasedAnn/Types.hs
+++ b/library/Core/src/Juvix/Core/ErasedAnn/Types.hs
@@ -3,12 +3,15 @@ module Juvix.Core.ErasedAnn.Types where
 import Juvix.Core.IR.Types (Universe)
 import Juvix.Library hiding (Type)
 import Juvix.Core.Application (ParamVar)
+import Juvix.Core.Parameterisation (TypedPrim')
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.Usage as Usage
 
 data T
 
 type instance ParamVar T = NameSymbol.T
+
+type TypedPrim ty val = TypedPrim' T ty val
 
 data Term primTy primVal
   = Var NameSymbol.T

--- a/library/Core/src/Juvix/Core/ErasedAnn/Types.hs
+++ b/library/Core/src/Juvix/Core/ErasedAnn/Types.hs
@@ -1,9 +1,9 @@
 module Juvix.Core.ErasedAnn.Types where
 
-import Juvix.Core.IR.Types (Universe)
-import Juvix.Library hiding (Type)
 import Juvix.Core.Application (ParamVar)
+import Juvix.Core.IR.Types (Universe)
 import Juvix.Core.Parameterisation (TypedPrim')
+import Juvix.Library hiding (Type)
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.Usage as Usage
 

--- a/library/Core/src/Juvix/Core/ErasedAnn/Types.hs
+++ b/library/Core/src/Juvix/Core/ErasedAnn/Types.hs
@@ -2,8 +2,13 @@ module Juvix.Core.ErasedAnn.Types where
 
 import Juvix.Core.IR.Types (Universe)
 import Juvix.Library hiding (Type)
+import Juvix.Core.Application (ParamVar)
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.Usage as Usage
+
+data T
+
+type instance ParamVar T = NameSymbol.T
 
 data Term primTy primVal
   = Var NameSymbol.T

--- a/library/Core/src/Juvix/Core/Erasure.hs
+++ b/library/Core/src/Juvix/Core/Erasure.hs
@@ -8,6 +8,7 @@ import Juvix.Core.Erasure.Algorithm
 import Juvix.Core.Erasure.Types
   ( Error (..),
     Globals,
+    MapPrim,
     Term,
     TermT,
     Type,
@@ -20,5 +21,4 @@ import Juvix.Core.Erasure.Types
     pattern Star,
     pattern SymT,
     pattern Var,
-    MapPrim,
   )

--- a/library/Core/src/Juvix/Core/Erasure.hs
+++ b/library/Core/src/Juvix/Core/Erasure.hs
@@ -20,4 +20,5 @@ import Juvix.Core.Erasure.Types
     pattern Star,
     pattern SymT,
     pattern Var,
+    MapPrim,
   )

--- a/library/Core/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/library/Core/src/Juvix/Core/Erasure/Algorithm.hs
@@ -9,24 +9,28 @@ import Juvix.Library hiding (empty)
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.Usage as Usage
 
-type ErasureM primTy primVal m =
+type ErasureM primTy1 primTy2 primVal1 primVal2 m =
   ( HasState "nextName" Int m,
     HasState "nameStack" [NameSymbol.T] m,
-    HasThrow "erasureError" (Erasure.Error primTy primVal) m
+    HasThrow "erasureError" (Erasure.Error primTy1 primVal1) m,
+    HasReader "mapPrimTy" ([NameSymbol.T] -> primTy1 -> primTy2) m,
+    HasReader "mapPrimVal" ([NameSymbol.T] -> primVal1 -> primVal2) m
   )
 
 erase ::
-  Typed.Term primTy primVal ->
+  ([NameSymbol.T] -> primTy1 -> primTy2) ->
+  ([NameSymbol.T] -> primVal1 -> primVal2) ->
+  Typed.Term primTy1 primVal1 ->
   Usage.T ->
-  Either (Erasure.Error primTy primVal) (Erasure.TermT primTy primVal)
-erase t π
+  Either (Erasure.Error primTy1 primVal1) (Erasure.TermT primTy2 primVal2)
+erase mt mv t π
   | π == mempty = Left $ Erasure.CannotEraseZeroUsageTerm t
-  | otherwise = exec $ eraseTerm t
+  | otherwise = exec mt mv $ eraseTerm t
 
 eraseGlobal ::
-  ErasureM primTy primVal m =>
-  Typed.GlobalT primTy primVal ->
-  m (Erasure.GlobalT primTy primVal)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.GlobalT primTy1 primVal1 ->
+  m (Erasure.GlobalT primTy2 primVal2)
 eraseGlobal g =
   case g of
     IR.GDatatype g -> Erasure.GDatatype |<< eraseDatatype g
@@ -37,41 +41,41 @@ eraseGlobal g =
     IR.GAbstract a -> Erasure.GAbstract |<< eraseAbstract a
 
 eraseAbstract ::
-  ErasureM primTy primVal m =>
-  Typed.AbstractT primTy primVal ->
-  m (Erasure.Abstract primTy)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.AbstractT primTy1 primVal1 ->
+  m (Erasure.Abstract primTy2)
 eraseAbstract (IR.Abstract name usage ty) =
   Erasure.Abstract name usage <$> eraseType ty
 
 eraseDatatype ::
-  ErasureM primTy primVal m =>
-  Typed.DatatypeT primTy primVal ->
-  m (Erasure.Datatype primTy)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.DatatypeT primTy1 primVal1 ->
+  m (Erasure.Datatype primTy2)
 eraseDatatype (IR.Datatype name args level cons) = do
   args <- mapM eraseDataArg args
   cons <- mapM eraseDataCon cons
   pure (Erasure.Datatype name args level cons)
 
 eraseDataArg ::
-  ErasureM primTy primVal m =>
-  Typed.DataArgT primTy primVal ->
-  m (Erasure.DataArg primTy)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.DataArgT primTy1 primVal1 ->
+  m (Erasure.DataArg primTy2)
 eraseDataArg (IR.DataArg name usage ty isParam) = do
   ty <- eraseType ty
   pure (Erasure.DataArg name usage ty isParam)
 
 eraseDataCon ::
-  ErasureM primTy primVal m =>
-  Typed.DataConT primTy primVal ->
-  m (Erasure.DataCon primTy)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.DataConT primTy1 primVal1 ->
+  m (Erasure.DataCon primTy2)
 eraseDataCon (IR.DataCon name ty) = do
   ty <- eraseType ty
   pure (Erasure.DataCon name ty)
 
 eraseFunction ::
-  ErasureM primTy primVal m =>
-  Typed.FunctionT primTy primVal ->
-  m (Erasure.FunctionT primTy primVal)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.FunctionT primTy1 primVal1 ->
+  m (Erasure.FunctionT primTy2 primVal2)
 eraseFunction (IR.Function name usage ty clauses) = do
   let (tys, ret) = piTypeToList (IR.quote0 ty)
   clauses <- flip mapM clauses $ \(IR.FunClause patts term) -> do
@@ -85,9 +89,9 @@ eraseFunction (IR.Function name usage ty clauses) = do
   pure (Erasure.Function name usage ty clauses)
 
 eraseFunClause ::
-  ErasureM primTy primVal m =>
-  Typed.FunClauseT primTy primVal ->
-  m (Erasure.FunClauseT primTy primVal)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.FunClauseT primTy1 primVal1 ->
+  m (Erasure.FunClauseT primTy2 primVal2)
 eraseFunClause (IR.FunClause patts term) = do
   patts <- mapM erasePattern patts
   -- TODO: Need the annotated term here. ref https://github.com/metastatedev/juvix/issues/495
@@ -96,9 +100,9 @@ eraseFunClause (IR.FunClause patts term) = do
   undefined
 
 erasePattern ::
-  ErasureM primTy primVal m =>
-  Typed.PatternT primTy primVal ->
-  m (Erasure.PatternT primTy primVal)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.PatternT primTy1 primVal1 ->
+  m (Erasure.PatternT primTy2 primVal2)
 erasePattern patt =
   case patt of
     IR.PCon name patts -> do
@@ -113,10 +117,21 @@ erasePattern patt =
       -- t <- eraseTerm t
       -- pure (Erasure.PDot t)
       pure (Erasure.PDot undefined)
-    IR.PPrim p -> pure (Erasure.PPrim p)
+    IR.PPrim p -> Erasure.PPrim <$> eraseTypedPrim p
+
+eraseTypedPrim ::
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.TypedPrim primTy1 primVal1 ->
+  m (Typed.TypedPrim primTy2 primVal2)
+eraseTypedPrim p = do
+  ns <- get @"nameStack"
+  mt <- ask @"mapPrimTy"
+  mv <- ask @"mapPrimVal"
+  pure $ bimap (fmap (mt ns)) (mv ns) p
+
 
 erasePatterns ::
-  ErasureM primTy' primVal' m =>
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
   ([pat], ([(Usage.Usage, arg)], ret)) ->
   m ([pat], ([(Usage.Usage, arg)], ret))
 erasePatterns ([], ([], ret)) = pure ([], ([], ret))
@@ -126,25 +141,29 @@ erasePatterns (p : ps, (arg : args, ret)) = do
   pure (p : ps', (arg : args', ret'))
 erasePatterns _ = throw @"erasureError" (Erasure.InternalError "invalid type & pattern match combination")
 
-piTypeToList :: IR.Term primTy primVal -> ([(Usage.Usage, IR.Term primTy primVal)], IR.Term primTy primVal)
+piTypeToList ::
+  IR.Term primTy primVal ->
+  ([(Usage.Usage, IR.Term primTy primVal)], IR.Term primTy primVal)
 piTypeToList ty =
   case ty of
     IR.Pi usage arg ret ->
       let (rest, res) = piTypeToList ret in ((usage, arg) : rest, res)
     _ -> ([], ty)
 
-listToPiType :: ([(Usage.Usage, IR.Term primTy primVal)], IR.Term primTy primVal) -> IR.Term primTy primVal
+listToPiType ::
+  ([(Usage.Usage, IR.Term primTy primVal)], IR.Term primTy primVal) ->
+  IR.Term primTy primVal
 listToPiType ([], ret) = ret
 listToPiType ((u, x) : xs, ret) = IR.Pi u x (listToPiType (xs, ret))
 
 eraseTerm ::
-  ErasureM primTy primVal m =>
-  Typed.Term primTy primVal ->
-  m (Erasure.TermT primTy primVal)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.Term primTy1 primVal1 ->
+  m (Erasure.TermT primTy2 primVal2)
 eraseTerm t@(Typed.Star _ _) = throwEra $ Erasure.UnsupportedTermT t
 eraseTerm t@(Typed.PrimTy _ _) = throwEra $ Erasure.UnsupportedTermT t
 eraseTerm (Typed.Prim p ann) = do
-  Erasure.Prim p <$> eraseType (IR.annType ann)
+  Erasure.Prim <$> eraseTypedPrim p <*> eraseType (IR.annType ann)
 eraseTerm t@(Typed.Pi _ _ _ _) = throwEra $ Erasure.UnsupportedTermT t
 eraseTerm (Typed.Lam t anns) = do
   let ty@(IR.VPi π _ _) = IR.annType $ IR.baResAnn anns
@@ -174,9 +193,9 @@ eraseTerm (Typed.Let π b t anns) = do
 eraseTerm (Typed.Elim e _) = eraseElim e
 
 eraseElim ::
-  ErasureM primTy primVal m =>
-  Typed.Elim primTy primVal ->
-  m (Erasure.TermT primTy primVal)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.Elim primTy1 primVal1 ->
+  m (Erasure.TermT primTy2 primVal2)
 eraseElim (Typed.Bound x ann) = do
   Erasure.Var <$> lookupBound x
     <*> eraseType (IR.annType ann)
@@ -197,14 +216,14 @@ eraseElim (Typed.Ann _ s _ _ _) = do
   eraseTerm s
 
 eraseType ::
-  forall primTy primVal m.
-  ErasureM primTy primVal m =>
-  Typed.ValueT primTy primVal ->
-  m (Erasure.Type primTy)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.ValueT primTy1 primVal1 ->
+  m (Erasure.Type primTy2)
 eraseType (IR.VStar i) = do
   pure $ Erasure.Star i
 eraseType (IR.VPrimTy t) = do
-  pure $ Erasure.PrimTy t
+  ns <- get @"nameStack"
+  Erasure.PrimTy <$> asks @"mapPrimTy" \mt -> mt ns t
 eraseType (IR.VPi π a b) = do
   if π == mempty
     then eraseType b
@@ -231,10 +250,9 @@ eraseType v@(IR.VPrim _) = do
   throwEra $ Erasure.UnsupportedTypeV v
 
 eraseTypeN ::
-  forall primTy primVal m.
-  ErasureM primTy primVal m =>
-  Typed.NeutralT primTy primVal ->
-  m (Erasure.Type primTy)
+  ErasureM primTy1 primTy2 primVal1 primVal2 m =>
+  Typed.NeutralT primTy1 primVal1 ->
+  m (Erasure.Type primTy2)
 eraseTypeN (IR.NBound x) = do
   Erasure.SymT <$> lookupBound x
 eraseTypeN (IR.NFree (IR.Global x)) = do

--- a/library/Core/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/library/Core/src/Juvix/Core/Erasure/Algorithm.hs
@@ -131,7 +131,6 @@ erasePrimVal p = do
   ask @"mapPrimVal" <*> get @"nameStack" <*> pure p
     >>= either (throw @"erasureError") pure
 
-
 erasePatterns ::
   ErasureM primTy1 primTy2 primVal1 primVal2 m =>
   ([pat], ([(Usage.Usage, arg)], ret)) ->

--- a/library/Core/src/Juvix/Core/Erasure/Types.hs
+++ b/library/Core/src/Juvix/Core/Erasure/Types.hs
@@ -21,6 +21,7 @@ import qualified Juvix.Core.Erased.Types as Erased
 import qualified Juvix.Core.Erased.Types.Base as Erased
 import qualified Juvix.Core.IR.Typechecker as TC
 import qualified Juvix.Core.IR.Typechecker.Types as Typed
+import qualified Juvix.Core.IR.Types as IR
 import Juvix.Core.IR.Types (GlobalName, GlobalUsage, PatternVar)
 import qualified Juvix.Core.Parameterisation as Param
 import Juvix.Library hiding (Datatype, Type, empty)
@@ -77,11 +78,11 @@ exec ::
 exec mt mv (EnvEra m) = evalState (runExceptT m) (Env 0 [] mt mv)
 
 data Error primTy primVal
-  = UnsupportedTermT (Typed.Term primTy primVal)
-  | UnsupportedTermE (Typed.Elim primTy primVal)
-  | UnsupportedTypeV (Typed.ValueT primTy primVal)
-  | UnsupportedTypeN (Typed.NeutralT primTy primVal)
-  | CannotEraseZeroUsageTerm (Typed.Term primTy primVal)
+  = UnsupportedTermT (Typed.Term' primTy primVal)
+  | UnsupportedTermE (Typed.Elim' primTy primVal)
+  | UnsupportedTypeV (IR.Value primTy primVal)
+  | UnsupportedTypeN (IR.Neutral primTy primVal)
+  | CannotEraseZeroUsageTerm (Typed.Term' primTy primVal)
   | TypeError (TC.TypecheckError primTy primVal)
   | InternalError Text
   deriving (Generic)

--- a/library/Core/src/Juvix/Core/Erasure/Types.hs
+++ b/library/Core/src/Juvix/Core/Erasure/Types.hs
@@ -19,7 +19,6 @@ import Juvix.Core.Erased.Types as Type
   )
 import qualified Juvix.Core.Erased.Types as Erased
 import qualified Juvix.Core.Erased.Types.Base as Erased
-import qualified Juvix.Core.IR.Typechecker as TC
 import qualified Juvix.Core.IR.Typechecker.Types as Typed
 import qualified Juvix.Core.IR.Types as IR
 import Juvix.Core.IR.Types (GlobalName, GlobalUsage, PatternVar)
@@ -83,23 +82,20 @@ data Error primTy primVal
   | UnsupportedTypeV (IR.Value primTy primVal)
   | UnsupportedTypeN (IR.Neutral primTy primVal)
   | CannotEraseZeroUsageTerm (Typed.Term' primTy primVal)
-  | TypeError (TC.TypecheckError primTy primVal)
   | InternalError Text
   deriving (Generic)
 
 deriving instance
   ( Show primTy,
     Show primVal,
-    Show (Param.ApplyErrorExtra primTy),
-    Show (Param.ApplyErrorExtra (Typed.TypedPrim primTy primVal))
+    Show (Param.ApplyErrorExtra primTy)
   ) =>
   Show (Error primTy primVal)
 
 deriving instance
   ( Eq primTy,
     Eq primVal,
-    Eq (Param.ApplyErrorExtra primTy),
-    Eq (Param.ApplyErrorExtra (Typed.TypedPrim primTy primVal))
+    Eq (Param.ApplyErrorExtra primTy)
   ) =>
   Eq (Error primTy primVal)
 

--- a/library/Core/src/Juvix/Core/Erasure/Types.hs
+++ b/library/Core/src/Juvix/Core/Erasure/Types.hs
@@ -30,18 +30,18 @@ import Juvix.Library.Usage (Usage)
 type MapPrim p1 p2 ty val =
   [NameSymbol.T] -> p1 -> Either (Error ty val) p2
 
-data Env primTy1 primTy2 primVal1 primVal2 =
-    Env {
-      nextName :: Int,
-      nameStack :: [NameSymbol.T],
-      mapPrimTy :: MapPrim primTy1 primTy2 primTy1 primVal1,
-      mapPrimVal :: MapPrim primVal1 primVal2 primTy1 primVal1
-    }
+data Env primTy1 primTy2 primVal1 primVal2
+  = Env
+      { nextName :: Int,
+        nameStack :: [NameSymbol.T],
+        mapPrimTy :: MapPrim primTy1 primTy2 primTy1 primVal1,
+        mapPrimVal :: MapPrim primVal1 primVal2 primTy1 primVal1
+      }
   deriving (Generic)
 
 type EnvEraAlias primTy1 primTy2 primVal1 primVal2 =
   ExceptT (Error primTy1 primVal1)
-          (State (Env primTy1 primTy2 primVal1 primVal2))
+    (State (Env primTy1 primTy2 primVal1 primVal2))
 
 newtype EnvT primTy1 primTy2 primVal1 primVal2 a
   = EnvEra (EnvEraAlias primTy1 primTy2 primVal1 primVal2 a)

--- a/library/Core/src/Juvix/Core/IR/Typechecker/Types.hs
+++ b/library/Core/src/Juvix/Core/IR/Typechecker/Types.hs
@@ -132,10 +132,10 @@ type PatternT' ext primTy primVal =
 
 type PatternT primTy primVal = PatternT' IR.NoExt primTy primVal
 
-type AbstractT' extV extT primTy primVal =
-  IR.Abstract' extV extT primTy (P.TypedPrim primTy primVal)
+type AbstractT' extV primTy primVal =
+  IR.Abstract' extV primTy (P.TypedPrim primTy primVal)
 
-type AbstractT primTy primVal = AbstractT' IR.NoExt IR.NoExt primTy primVal
+type AbstractT primTy primVal = AbstractT' IR.NoExt primTy primVal
 
 type GlobalsT' extV extT primTy primVal =
   IR.Globals' extV extT primTy (P.TypedPrim primTy primVal)

--- a/library/Core/src/Juvix/Core/IR/Typechecker/Types.hs
+++ b/library/Core/src/Juvix/Core/IR/Typechecker/Types.hs
@@ -162,7 +162,7 @@ type BindAnnotationT' ext primTy primVal =
 
 type BindAnnotationT primTy primVal = BindAnnotationT' IR.NoExt primTy primVal
 
-getTermAnn :: Term primTy primVal -> AnnotationT' IR.NoExt primTy primVal
+getTermAnn :: Term' primTy primVal -> Annotation primTy primVal
 getTermAnn (Star _ ann) = ann
 getTermAnn (PrimTy _ ann) = ann
 getTermAnn (Prim _ ann) = ann
@@ -175,7 +175,7 @@ getTermAnn (Lam _ anns) = baResAnn anns
 getTermAnn (Let _ _ _ anns) = baResAnn anns
 getTermAnn (Elim _ ann) = ann
 
-getElimAnn :: Elim primTy primVal -> AnnotationT' IR.NoExt primTy primVal
+getElimAnn :: Elim' primTy primVal -> Annotation primTy primVal
 getElimAnn (Bound _ ann) = ann
 getElimAnn (Free _ ann) = ann
 getElimAnn (App _ _ ann) = ann

--- a/library/Core/src/Juvix/Core/IR/Types.hs
+++ b/library/Core/src/Juvix/Core/IR/Types.hs
@@ -70,6 +70,10 @@ type FunClause = FunClause' NoExt
 
 -- (no RawFunClause since a clause contains no types anyway)
 
+type Abstract = Abstract' NoExt
+
+type RawAbstract = RawAbstract' NoExt
+
 type Global = Global' NoExt NoExt
 
 type RawGlobal = RawGlobal' NoExt

--- a/library/Core/src/Juvix/Core/IR/Types/Base.hs
+++ b/library/Core/src/Juvix/Core/IR/Types/Base.hs
@@ -215,7 +215,7 @@ deriving instance
   GlobalAll NFData ext primTy primVal =>
   NFData (FunClause' ext primTy primVal)
 
-data AbstractWith ty ext primTy primVal
+data AbstractWith ty (primTy :: *) (primVal :: *)
   = Abstract
       { absName :: GlobalName,
         absUsage :: GlobalUsage,
@@ -223,31 +223,31 @@ data AbstractWith ty ext primTy primVal
       }
   deriving (Generic)
 
-type RawAbstract' ext = AbstractWith (Term' ext) ext
+type RawAbstract' ext = AbstractWith (Term' ext)
 
 type Abstract' extV = AbstractWith (Value' extV)
 
 deriving instance
-  GlobalAllWith Show ty ext primTy primVal =>
-  Show (AbstractWith ty ext primTy primVal)
+  Show (ty primTy primVal) =>
+  Show (AbstractWith ty primTy primVal)
 
 deriving instance
-  GlobalAllWith Eq ty ext primTy primVal =>
-  Eq (AbstractWith ty ext primTy primVal)
+  Eq (ty primTy primVal) =>
+  Eq (AbstractWith ty primTy primVal)
 
 deriving instance
-  (Typeable ty, Data ext, GlobalAllWith Data ty ext primTy primVal) =>
-  Data (AbstractWith ty ext primTy primVal)
+  (Typeable ty, Typeable primTy, Typeable primVal, Data (ty primTy primVal)) =>
+  Data (AbstractWith ty primTy primVal)
 
 deriving instance
-  GlobalAllWith NFData ty ext primTy primVal =>
-  NFData (AbstractWith ty ext primTy primVal)
+  NFData (ty primTy primVal) =>
+  NFData (AbstractWith ty primTy primVal)
 
 data GlobalWith ty ext primTy primVal
   = GDatatype (DatatypeWith ty primTy primVal)
   | GDataCon (DataConWith ty primTy primVal)
   | GFunction (FunctionWith ty ext primTy primVal)
-  | GAbstract (AbstractWith ty ext primTy primVal)
+  | GAbstract (AbstractWith ty primTy primVal)
   deriving (Generic)
 
 type RawGlobal' ext = GlobalWith (Term' ext) ext

--- a/library/Core/src/Juvix/Core/Parameterisation.hs
+++ b/library/Core/src/Juvix/Core/Parameterisation.hs
@@ -5,6 +5,7 @@ module Juvix.Core.Parameterisation where
 import qualified Juvix.Core.Application as App
 import Juvix.Library
 import Juvix.Library.HashMap (HashMap)
+import Juvix.Core.IR.Types (NoExt)
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -73,4 +74,5 @@ apply1 f x = apply f (x :| [])
 apply1Maybe :: CanApply a => a -> a -> Maybe a
 apply1Maybe f x = applyMaybe f (x :| [])
 
-type TypedPrim ty val = App.Return (PrimType ty) val
+type TypedPrim' ext ty val = App.Return' ext (PrimType ty) val
+type TypedPrim ty val = TypedPrim' NoExt ty val

--- a/library/Core/src/Juvix/Core/Parameterisation.hs
+++ b/library/Core/src/Juvix/Core/Parameterisation.hs
@@ -3,9 +3,9 @@
 module Juvix.Core.Parameterisation where
 
 import qualified Juvix.Core.Application as App
+import Juvix.Core.IR.Types (NoExt)
 import Juvix.Library
 import Juvix.Library.HashMap (HashMap)
-import Juvix.Core.IR.Types (NoExt)
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
@@ -75,4 +75,5 @@ apply1Maybe :: CanApply a => a -> a -> Maybe a
 apply1Maybe f x = applyMaybe f (x :| [])
 
 type TypedPrim' ext ty val = App.Return' ext (PrimType ty) val
+
 type TypedPrim ty val = TypedPrim' NoExt ty val

--- a/library/Core/src/Juvix/Core/Parameterisations/All.hs
+++ b/library/Core/src/Juvix/Core/Parameterisations/All.hs
@@ -10,6 +10,7 @@ import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
 import Prelude (String)
+import Data.Coerce
 
 -- all primitive types
 data Ty
@@ -72,31 +73,44 @@ instance P.CanApply (P.TypedPrim Ty Val) where
 
 natValR :: P.TypedPrim Naturals.Ty Naturals.Val -> P.TypedPrim Ty Val
 natValR (App.Cont {fun, args, numLeft}) =
-  App.Cont {App.fun = natValT fun, App.args = natValT <$> args, numLeft}
+  App.Cont {App.fun = natValT fun, App.args = natValTF <$> args, numLeft}
 natValR (App.Return {retType, retTerm}) =
   App.Return {retType = NatTy <$> retType, retTerm = NatVal retTerm}
+
+natValTF ::
+  Functor f =>
+  App.Take (P.PrimType Naturals.Ty) (f Naturals.Val) ->
+  App.Take (P.PrimType Ty) (f Val)
+natValTF (App.Take {usage, type', term}) =
+  App.Take {usage, type' = NatTy <$> type', term = NatVal <$> term}
 
 natValT ::
   App.Take (P.PrimType Naturals.Ty) Naturals.Val ->
   App.Take (P.PrimType Ty) Val
-natValT (App.Take {usage, type', term}) =
-  App.Take {usage, type' = NatTy <$> type', term = NatVal term}
+natValT = coerce (natValTF @Identity)
 
 unNatValR :: P.TypedPrim Ty Val -> Maybe (P.TypedPrim Naturals.Ty Naturals.Val)
 unNatValR (App.Cont {fun, args, numLeft}) =
-  App.Cont <$> unNatValT fun <*> traverse unNatValT args <*> pure numLeft
+  App.Cont <$> unNatValT fun <*> traverse unNatValTF args <*> pure numLeft
 unNatValR (App.Return {retType = t', retTerm = NatVal v})
   | Just t <- traverse unNatTy t' =
     Just $ App.Return t v
 unNatValR (App.Return {}) = Nothing
 
+unNatValTF ::
+  Traversable f =>
+  App.Take (P.PrimType Ty) (f Val) ->
+  Maybe (App.Take (P.PrimType Naturals.Ty) (f Naturals.Val))
+unNatValTF (App.Take {usage, type' = type'', term = term'})
+  | Just type' <- traverse unNatTy type'',
+    Just term  <- traverse unNatVal term' =
+    Just $ App.Take {usage, type', term}
+unNatValTF (App.Take {}) = Nothing
+
 unNatValT ::
   App.Take (P.PrimType Ty) Val ->
   Maybe (App.Take (P.PrimType Naturals.Ty) Naturals.Val)
-unNatValT (App.Take {usage, type' = type'', term = NatVal term})
-  | Just type' <- traverse unNatTy type'' =
-    Just $ App.Take {usage, type', term}
-unNatValT (App.Take {}) = Nothing
+unNatValT = coerce (unNatValTF @Identity)
 
 unNatVal :: Val -> Maybe Naturals.Val
 unNatVal (NatVal n) = Just n

--- a/library/Core/src/Juvix/Core/Parameterisations/All.hs
+++ b/library/Core/src/Juvix/Core/Parameterisations/All.hs
@@ -2,6 +2,7 @@
 
 module Juvix.Core.Parameterisations.All where
 
+import Data.Coerce
 import qualified Juvix.Core.Application as App
 import qualified Juvix.Core.Parameterisation as P
 import qualified Juvix.Core.Parameterisations.Naturals as Naturals
@@ -10,7 +11,6 @@ import Juvix.Library hiding ((<|>))
 import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
 import Prelude (String)
-import Data.Coerce
 
 -- all primitive types
 data Ty
@@ -103,7 +103,7 @@ unNatValTF ::
   Maybe (App.Take (P.PrimType Naturals.Ty) (f Naturals.Val))
 unNatValTF (App.Take {usage, type' = type'', term = term'})
   | Just type' <- traverse unNatTy type'',
-    Just term  <- traverse unNatVal term' =
+    Just term <- traverse unNatVal term' =
     Just $ App.Take {usage, type', term}
 unNatValTF (App.Take {}) = Nothing
 

--- a/library/Core/src/Juvix/Core/Types.hs
+++ b/library/Core/src/Juvix/Core/Types.hs
@@ -19,7 +19,7 @@ data PipelineError primTy primVal compErr
   = InternalInconsistencyError Text
   | TypecheckerError (TC.TypecheckError primTy primVal)
   | -- | EACError (EAC.Errors primTy primVal)
-    ErasureError (Erasure.Error primTy primVal)
+    ErasureError (Erasure.Error primTy (TypedPrim primTy primVal))
   | PrimError compErr
   deriving (Generic)
 

--- a/library/Core/test/Erasure.hs
+++ b/library/Core/test/Erasure.hs
@@ -36,8 +36,10 @@ shouldEraseTo name _ (term, usage) erased =
   T.testCase
     (name <> ": " <> show (term, usage) <> " should erase to " <> show erased)
     ( Right erased
-        T.@=? (Erasure.eraseAnn |<< Erasure.erase term usage)
+        T.@=? (Erasure.eraseAnn |<< erase term usage)
     )
+  where
+    erase = Erasure.erase (const pure) (const pure)
 
 infix 0 `ann`
 

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -67,15 +67,15 @@ exec (EnvE env) param globals = do
   (ret, env) <- runStateT (runExceptT env) (Env param [] globals)
   pure (ret, log env)
 
-type Globals = IR.Globals PrimTy PrimVal
+type Globals = IR.Globals PrimTy PrimValIR
 
 type RawHRElim = HR.Elim PrimTy RawPrimVal
 
-type HRElim = HR.Elim PrimTy PrimVal
+type HRElim = HR.Elim PrimTy PrimValHR
 
 type RawHRTerm = HR.Term PrimTy RawPrimVal
 
-type HRTerm = HR.Term PrimTy PrimVal
+type HRTerm = HR.Term PrimTy PrimValHR
 
 type AnnTuple = (RawHRTerm, Usage.T, RawHRTerm)
 


### PR DESCRIPTION
Fixes #630.

Concretely, this PR adds a new datatype for primitive arguments, which can contain variables. This seems to be a cleaner solution than making `Prim` a neutral?

Bear in mind that this patch means that `Cont {args, numLeft=0}` is now a well-formed `Return`, as long as at least one of `args` is a variable. (Previously `numLeft` had to be non-zero since a fully-saturated application was always reducible.)

- [ ] Add `HasSubst` for `Application` stuff, and use it in terms
  - [ ] (Remember to retry reduction after substituting!)
- [x] `ErasedAnn` doesn't use de Bruijn. Address that....... somehow